### PR TITLE
Correct a couple of minor spelling mistakes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,6 @@
 Thank you for considering improving `Loguru`, any contribution is much welcome!
 
-.. _minimal reproducable example: https://stackoverflow.com/help/mcve
+.. _minimal reproducible example: https://stackoverflow.com/help/mcve
 .. _open a new issue: https://github.com/Delgan/loguru/issues/new
 .. _open a pull request: https://github.com/Delgan/loguru/compare
 .. _PEP 8: https://www.python.org/dev/peps/pep-0008/
@@ -23,15 +23,15 @@ An ideal bug report includes:
 * The `Loguru` version you are using (you can find it with ``print(loguru.__version__)``)
 * Your operating system name and version
 * Your development environment and local setup (IDE, Terminal, project context, anything that could be useful)
-* Some `minimal reproducable example`_
+* Some `minimal reproducible example`_
 
 
 Implementing changes
 --------------------
 
-If you are willing to enhance `Loguru` by implementing non-trivial changes, please `open a new issue`_ first to keep a reference about why such modifications are made (and potentialy avoid unneeded work). Then, the workflow would look as follow:
+If you are willing to enhance `Loguru` by implementing non-trivial changes, please `open a new issue`_ first to keep a reference about why such modifications are made (and potentially avoid unneeded work). Then, the workflow would look as follow:
 
-1. Fork the `Loguru`_ project from Github
+1. Fork the `Loguru`_ project from GitHub
 2. Clone the repository locally::
 
     $ git clone git@github.com:your_name_here/loguru.git

--- a/README.rst
+++ b/README.rst
@@ -178,13 +178,13 @@ Modern string formatting using braces style
 Exceptions catching within threads or main
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Have you ever seen your program crashing unexpectedly without seeing anything in the logfile? Did you ever noticed that exceptions occuring in threads were not logged? This can be solved using the |catch|_ decorator / context manager which ensures that any error is correctly propagated to the |logger|_.
+Have you ever seen your program crashing unexpectedly without seeing anything in the logfile? Did you ever noticed that exceptions occurring in threads were not logged? This can be solved using the |catch|_ decorator / context manager which ensures that any error is correctly propagated to the |logger|_.
 
 ::
 
     @logger.catch
     def my_function(x, y, z):
-        # An error? It's catched anyway!
+        # An error? It's caught anyway!
         return 1 / (x + y + z)
 
 
@@ -313,7 +313,7 @@ The standard logging is bloated with arguments like ``datefmt`` or ``msecs``, ``
 Suitable for scripts and libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Using the logger in your scripts is easy, and you can |configure|_ it at start. To use `Loguru` from inside a libary, remember to never call |add|_ but use |disable|_ instead so logging functions become no-op. If a developer wishes to see your library's logs, he can |enable|_ it again.
+Using the logger in your scripts is easy, and you can |configure|_ it at start. To use `Loguru` from inside a library, remember to never call |add|_ but use |disable|_ instead so logging functions become no-op. If a developer wishes to see your library's logs, he can |enable|_ it again.
 
 ::
 
@@ -426,7 +426,7 @@ Exhaustive notifier
 
 |/strike|
 
-Although logging impact on performances is in most cases negligeable, a zero-cost logger would allow to use it anywhere without much concern. In an upcoming release, Loguru's critical functions will be implemented in C for maximum speed.
+Although logging impact on performances is in most cases negligible, a zero-cost logger would allow to use it anywhere without much concern. In an upcoming release, Loguru's critical functions will be implemented in C for maximum speed.
 
 
 .. |strike| raw:: html


### PR DESCRIPTION
Thanks, this library looks really useful. I was reading some of the documentation and noticed a couple of spelling mistakes.  I have tried to only correct words that seem wrong rather than any differences between British and American English.