### PR TITLE
tests/test_formatting: use __file__

### DIFF
--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -18,7 +18,7 @@ from ansimarkup import AnsiMarkupError
         ("{level.icon}", lambda r: r == "🐞"),
         ("{file}", lambda r: r == "test_formatting.py"),
         ("{file.name}", lambda r: r == "test_formatting.py"),
-        ("{file.path}", lambda r: re.fullmatch(r".*tests[/\\]test_formatting.py", r)),
+        ("{file.path}", lambda r: r == __file__),
         ("{function}", lambda r: r == "test_log_formatters"),
         ("{module}", lambda r: r == "test_formatting"),
         ("{thread}", lambda r: re.fullmatch(r"\d+", r)),


### PR DESCRIPTION
It could be used in more places there, but I think that is fine for now.

I've noticed this when copying the file to another name for a new test
being added there (to compare against master).