### PR TITLE
[RFC] Allow to configure exception formatter

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -93,12 +93,12 @@ class Handler:
 
             formatter_record = record.copy()
 
-            if not record["exception"]:
-                error = ""
-            else:
+            if record["exception"] and self._exception_formatter:
                 type_, value, tb = record["exception"]
                 lines = self._exception_formatter.format_exception(type_, value, tb)
                 error = "".join(lines)
+            else:
+                error = ""
 
             formatter_record["exception"] = error
 

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -743,6 +743,23 @@ class Logger:
                 "Invalid level value, it should be a positive integer, not: %d" % levelno
             )
 
+        try:
+            encoding = sink.encoding
+        except AttributeError:
+            encoding = None
+
+        if not encoding:
+            encoding = "ascii"
+
+        if exception_formatter is UNSET:
+            exception_formatter = ExceptionFormatter(
+                colorize=colorize,
+                encoding=encoding,
+                diagnose=diagnose,
+                backtrace=backtrace,
+                hidden_frames_filename=self.catch.__code__.co_filename,
+            )
+
         if isinstance(format, str):
             formatter = format + "\n{exception}"
             is_formatter_dynamic = False
@@ -755,26 +772,9 @@ class Logger:
                 % type(format).__name__
             )
 
-        try:
-            encoding = sink.encoding
-        except AttributeError:
-            encoding = None
-
-        if not encoding:
-            encoding = "ascii"
-
         with self._lock:
             handler_id = next(self._handlers_count)
             colors = [lvl.color for lvl in self._levels.values()] + [""]
-
-            if exception_formatter is UNSET:
-                exception_formatter = ExceptionFormatter(
-                    colorize=colorize,
-                    encoding=encoding,
-                    diagnose=diagnose,
-                    backtrace=backtrace,
-                    hidden_frames_filename=self.catch.__code__.co_filename,
-                )
 
             handler = Handler(
                 writer=writer,

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -32,6 +32,8 @@ Level = namedtuple("Level", ["no", "color", "icon"])
 
 start_time = now()
 
+UNSET = object()
+
 
 class Logger:
     """An object to dispatch logging messages to configured handlers.
@@ -163,6 +165,7 @@ class Logger:
         diagnose=_defaults.LOGURU_DIAGNOSE,
         enqueue=_defaults.LOGURU_ENQUEUE,
         catch=_defaults.LOGURU_CATCH,
+        exception_formatter=UNSET,
         **kwargs
     ):
         r"""Add a handler sending log messages to a sink adequately configured.
@@ -201,6 +204,8 @@ class Logger:
             Whether or not errors occurring while sink handles logs messages should be caught or
             not. If ``True``, an exception message is displayed on |sys.stderr| but the exception is
             not propagated to the caller, preventing your app to crash.
+        exception_formatter : |ExceptionFormatter|, optional
+            By default ``loguru._better_exceptions.ExceptionFormatter`` is used.
         **kwargs
             Additional parameters that will be passed to the sink while creating it or while
             logging messages (the exact behavior depends on the sink type).
@@ -762,13 +767,14 @@ class Logger:
             handler_id = next(self._handlers_count)
             colors = [lvl.color for lvl in self._levels.values()] + [""]
 
-            exception_formatter = ExceptionFormatter(
-                colorize=colorize,
-                encoding=encoding,
-                diagnose=diagnose,
-                backtrace=backtrace,
-                hidden_frames_filename=self.catch.__code__.co_filename,
-            )
+            if exception_formatter is UNSET:
+                exception_formatter = ExceptionFormatter(
+                    colorize=colorize,
+                    encoding=encoding,
+                    diagnose=diagnose,
+                    backtrace=backtrace,
+                    hidden_frames_filename=self.catch.__code__.co_filename,
+                )
 
             handler = Handler(
                 writer=writer,

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -761,7 +761,9 @@ class Logger:
             )
 
         if isinstance(format, str):
-            formatter = format + "\n{exception}"
+            formatter = format
+            if exception_formatter:
+                formatter += "\n{exception}"
             is_formatter_dynamic = False
         elif callable(format):
             formatter = format

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -121,3 +121,20 @@ def test_extra_formatting(writer):
 def test_invalid_color_markup(writer):
     with pytest.raises(AnsiMarkupError):
         logger.add(writer, format="<red>Not closed tag", colorize=True)
+
+
+def test_handler_with_no_exception_formatter():
+    class Handler:
+        def write(self, message):
+            assert message == "got_exception"
+            self.passed_write = True
+
+    handler = Handler()
+    logger.add(handler, format="{message}", catch=False, exception_formatter=None)
+    assert [x._exception_formatter for x in logger._handlers.values()] == [None]
+    try:
+        raise ValueError
+    except Exception:
+        logger.exception("got_exception")
+
+    assert handler.passed_write is True


### PR DESCRIPTION
TODO:

- [ ] base class / interface for formatters?
- [ ] I've moved code out of the `with self._lock` block, but I think that is OK (initially added there in https://github.com/blueyed/loguru/commit/04aba79e6b0175eef075a0bb3776a90876da3332#diff-4446c03371d87929a4cefc5c88a52f36R764)

Came across this when looking at https://github.com/Delgan/loguru/issues/59, i.e. when you want to be compatible to `logging`, no exceptions should be added also.