### PR TITLE
Use tox for tests (#41)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 dist: xenial
+
 sudo: required
 
 python:
@@ -11,9 +12,10 @@ python:
 
 install:
   - pip install -e .[dev]
+  - pip install tox-travis
+  - pip install codecov
 
-script:
-  - pytest --cov loguru/
+script: tox
 
 after_success:
   - codecov --flags "py${TRAVIS_PYTHON_VERSION//./}"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 - Fix ``logger.catch`` decorator not working with generator and coroutine functions (`#75 <https://github.com/Delgan/loguru/issues/75>`_)
 - Fix ``record["path"]`` case being normalized for no necessary reason (`#85 <https://github.com/Delgan/loguru/issues/85>`_)
 - Fix handler addded with ``enqueue=True`` stopping working if exception was raised in sink although ``catch=True``
+- Tox should now be used for tests (`#41 <https://github.com/Delgan/loguru/issues/41>`_)
 
 
 0.2.5 (2019-01-20)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,7 +55,7 @@ If you are willing to enhance `Loguru` by implementing non-trivial changes, plea
 6. Implement the modifications wished. During the process of development, honor `PEP 8`_ as much as possible.
 7. Add unit tests (don't hesitate to be exhaustive!) and ensure none are failing using::
 
-    $ pytest tests
+    $ tox
 
 8. Remember to update documentation if required
 9. Update the ``changelog.rst`` file with what you improved

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1423,7 +1423,7 @@ class Logger:
             activation_list = [(n, s) for n, s in self._activation_list if n[: len(name)] != name]
 
         parent_status = next((s for n, s in activation_list if name[: len(n)] == n), None)
-        if parent_status != status and not (name == "" and status == True):
+        if parent_status != status and not (name == "" and status is True):
             activation_list.append((name, status))
 
             def key_sort(x):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+###############
+##### Tox #####
+###############
+[tox:tox]
+skipsdist = True
+skip_missing_interpreters = True
+distshare = {homedir}/.tox/distshare
+envlist = py{35,36,37,pypy}
+indexserver = pypi = https://pypi.python.org/simple
+
+[testenv]
+passenv = TRAVIS TRAVIS_*
+setenv = PYTHONPATH = {toxinidir}
+commands =
+    pip install -e .[dev]
+    pytest --pep8 loguru/
+    pytest --cov loguru/
+    coverage report -m
+deps =
+    pytest-pep8>=1.0.6
+    pytest-cov>=2.7.1
+
+
+
+##################
+##### Pytest #####
+##################
+[tool:pytest]
+addopts = -vvl
+pep8maxlinelength = 100
+pep8ignore =
+    * W503  # Line break before binary operator (PEP8 now recommend to break after binary operator)
+    * E203  # Whitespace before ":" in slices
+
+
+####################
+##### Coverage #####
+####################
+[coverage:html]
+title = Loguru Coverage

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,7 @@ setup(
     ],
     extras_require={
         "dev": [
-            "codecov>=2.0.15",
-            "isort>=4.3.4",
-            "pytest>=3.9.0",
-            "pytest-cov>=2.5.1",
+            "tox>=3.9.0",
             "Sphinx>=1.7.4",
             "sphinx-autobuild>=0.7",
             "sphinx-rtd-theme>=0.3",


### PR DESCRIPTION
#41 

Both travis and local tests can now be done through `tox`.

Changes :

* Some files modified in `loguru/` to be compliant with PEP 8
* Moving tests dependencies for setup.py to setup.cfg