### PR TITLE
Fix a problem of raw option with handler

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -108,7 +108,13 @@ class Handler:
 
             if is_raw:
                 if not is_ansi:
-                    formatted = message
+                    if self._is_formatter_dynamic:
+                        formatted = message
+                    else:
+                        if hasattr(self._writer, "read"):
+                            formatted = message
+                        else:
+                            formatted = message + '\n'
                 elif self._colorize:
                     level_ansi = self._levels_ansi_codes[level_id]
                     formatted = self._colorize_format(message, level_ansi)

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -108,13 +108,7 @@ class Handler:
 
             if is_raw:
                 if not is_ansi:
-                    if self._is_formatter_dynamic:
-                        formatted = message
-                    else:
-                        if hasattr(self._writer, "read"):
-                            formatted = message
-                        else:
-                            formatted = message + '\n'
+                    formatted = message
                 elif self._colorize:
                     level_ansi = self._levels_ansi_codes[level_id]
                     formatted = self._colorize_format(message, level_ansi)

--- a/tests/test_standard_handler.py
+++ b/tests/test_standard_handler.py
@@ -96,7 +96,7 @@ def test_exception_formatting(tmpdir):
 def test_standard_formatter(capsys, dynamic_format):
     fmt = "{level.no} {message} [Not Chopped]"
     if dynamic_format:
-        format_ = lambda x: fmt
+        def format_(x): return fmt
     else:
         format_ = fmt
     handler = StreamHandler(sys.stdout)
@@ -113,7 +113,7 @@ def test_standard_formatter(capsys, dynamic_format):
 def test_standard_formatter_with_new_line(capsys, dynamic_format):
     fmt = "{level.no} {message}\n"
     if dynamic_format:
-        format_ = lambda x: fmt
+        def format_(x): return fmt
     else:
         format_ = fmt
     handler = StreamHandler(sys.stdout)
@@ -123,4 +123,38 @@ def test_standard_formatter_with_new_line(capsys, dynamic_format):
     logger.info("Test")
     out, err = capsys.readouterr()
     assert out == "20 Test\n INFO\n"
+    assert err == ""
+
+
+@pytest.mark.parametrize("dynamic_format", [False, True])
+def test_raw_standard_formatter(capsys, dynamic_format):
+    fmt = "{level.no} {message} [Not Chopped]"
+    if dynamic_format:
+        def format_(x): return fmt
+    else:
+        format_ = fmt
+    handler = StreamHandler(sys.stdout)
+    formatter = Formatter("%(message)s %(levelname)s")
+    handler.setFormatter(formatter)
+    logger.add(handler, format=format_)
+    logger.opt(raw=True).info("Test")
+    out, err = capsys.readouterr()
+    assert out == "Test INFO\n"
+    assert err == ""
+
+
+@pytest.mark.parametrize("dynamic_format", [False, True])
+def test_raw_standard_formatter_with_new_line(capsys, dynamic_format):
+    fmt = "{level.no} {message}\n"
+    if dynamic_format:
+        def format_(x): return fmt
+    else:
+        format_ = fmt
+    handler = StreamHandler(sys.stdout)
+    formatter = Formatter("%(message)s %(levelname)s")
+    handler.setFormatter(formatter)
+    logger.add(handler, format=format_)
+    logger.opt(raw=True).info("Test")
+    out, err = capsys.readouterr()
+    assert out == "Test INFO\n"
     assert err == ""


### PR DESCRIPTION
- Using raw option with handler, the message is cutted last 1 length

When I test my application with loguru, I found something weird.

```
logger.add(
        sink=LogstashHandler(host, port, "my-app", tags),
        format=LOGSTASH_FORMAT,
        level=level
    )
logger.opt(raw=True).error("hello")

Result: {... 'message': 'hell' ...}
```

As you could see, If I use handler with raw option, I couldn't get full message on the log.
So I tried to find this solution then somewhat dealt with it with test code.