### PR TITLE
Fix multiprocessing on Windows and add possibility of using independent loggers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 - Prevent hypothetical ``ImportError`` if a Python installation is missing the built-in ``distutils`` module (`#118 <https://github.com/Delgan/loguru/issues/118>`_).
+- Fix an error using a ``filter`` function "by name" while receiving a log with ``record["name"]`` equals to ``None``.
 
 
 0.3.2 (2019-07-21)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 
+- Fix incompatibility with ``multiprocessing`` on Windows by entirely refactoring the internal structure of the ``logger`` so it can be inherited by child processes along with added handlers (`#108 <https://github.com/Delgan/loguru/issues/108>`_).
 - Add support for ``copy.deepcopy()`` of the ``logger`` allowing multiple independent loggers with separate set of handlers (`#72 <https://github.com/Delgan/loguru/issues/72>`_).
 - Prevent hypothetical ``ImportError`` if a Python installation is missing the built-in ``distutils`` module (`#118 <https://github.com/Delgan/loguru/issues/118>`_).
 - Fix an error using a ``filter`` function "by name" while receiving a log with ``record["name"]`` equals to ``None``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 
+- Add support for ``copy.deepcopy()`` of the ``logger`` allowing multiple independent loggers with separate set of handlers (`#72 <https://github.com/Delgan/loguru/issues/72>`_).
 - Prevent hypothetical ``ImportError`` if a Python installation is missing the built-in ``distutils`` module (`#118 <https://github.com/Delgan/loguru/issues/118>`_).
 - Fix an error using a ``filter`` function "by name" while receiving a log with ``record["name"]`` equals to ``None``.
 

--- a/loguru/__init__.py
+++ b/loguru/__init__.py
@@ -7,13 +7,13 @@ import atexit as _atexit
 import sys as _sys
 
 from . import _defaults
-from ._logger import Logger as _Logger
+from ._logger import Logger as _Logger, Core as _Core
 
 __version__ = "0.3.2"
 
 __all__ = ["logger"]
 
-logger = _Logger(None, 0, False, False, False, False, None, {})
+logger = _Logger(_Core(), None, 0, False, False, False, False, None, {})
 
 if _defaults.LOGURU_AUTOINIT and _sys.stderr:
     logger.add(_sys.stderr)

--- a/loguru/_ctime_functions.py
+++ b/loguru/_ctime_functions.py
@@ -1,0 +1,35 @@
+import os
+
+if os.name == "nt":
+    import win32_setctime
+
+    def get_ctime(filepath):
+        return os.stat(filepath).st_ctime
+
+    def set_ctime(filepath, timestamp):
+        if win32_setctime.SUPPORTED:
+            win32_setctime.setctime(filepath, timestamp)
+
+
+elif hasattr(os.stat_result, "st_birthtime"):
+
+    def get_ctime(filepath):
+        return os.stat(filepath).st_birthtime
+
+    def set_ctime(filepath, timestamp):
+        pass
+
+
+else:
+
+    def get_ctime(filepath):
+        try:
+            return float(os.getxattr(filepath, b"user.loguru_crtime"))
+        except OSError:
+            return os.stat(filepath).st_mtime
+
+    def set_ctime(filepath, timestamp):
+        try:
+            os.setxattr(filepath, b"user.loguru_crtime", str(timestamp).encode("ascii"))
+        except OSError:
+            pass

--- a/loguru/_file_sink.py
+++ b/loguru/_file_sink.py
@@ -139,7 +139,6 @@ class FileSink:
         **kwargs
     ):
         self.encoding = locale.getpreferredencoding(False) if encoding is None else encoding
-        self.name = str(path)
 
         self._kwargs = {**kwargs, "mode": mode, "buffering": buffering, "encoding": self.encoding}
         self._path = str(path)

--- a/loguru/_file_sink.py
+++ b/loguru/_file_sink.py
@@ -1,3 +1,4 @@
+import abc
 import datetime as datetime_
 import decimal
 import glob
@@ -6,8 +7,10 @@ import numbers
 import os
 import shutil
 import string
+from functools import partial
 
 from . import _string_parsers as string_parsers
+from ._ctime_functions import get_ctime, set_ctime
 from ._datetime import aware_now, datetime
 
 
@@ -19,6 +22,106 @@ class FileDateFormatter:
         if not spec:
             spec = "%Y-%m-%d_%H-%M-%S_%f"
         return self.datetime.__format__(spec)
+
+
+class Compression:
+    @staticmethod
+    def add_compress(path_in, path_out, opener, **kwargs):
+        with opener(path_out, **kwargs) as f_comp:
+            f_comp.add(path_in, os.path.basename(path_in))
+
+    @staticmethod
+    def write_compress(path_in, path_out, opener, **kwargs):
+        with opener(path_out, **kwargs) as f_comp:
+            f_comp.write(path_in, os.path.basename(path_in))
+
+    @staticmethod
+    def copy_compress(path_in, path_out, opener, **kwargs):
+        with open(path_in, "rb") as f_in:
+            with opener(path_out, **kwargs) as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+    @staticmethod
+    def compression(path_in, ext, compress_function):
+        path_out = "{}.{}".format(path_in, ext)
+        if os.path.isfile(path_out):
+            creation_time = get_ctime(path_out)
+            creation_datetime = datetime.fromtimestamp(creation_time)
+            date = FileDateFormatter(creation_datetime)
+            root, ext_before = os.path.splitext(path_in)
+            renamed_path = "{}.{}{}.{}".format(root, date, ext_before, ext)
+            os.rename(path_out, renamed_path)
+        compress_function(path_in, path_out)
+        os.remove(path_in)
+
+
+class Retention:
+    @staticmethod
+    def retention_count(logs, number):
+        def key_log(log):
+            return (-os.stat(log).st_mtime, log)
+
+        for log in sorted(logs, key=key_log)[number:]:
+            os.remove(log)
+
+    @staticmethod
+    def retention_age(logs, seconds):
+        t = datetime.now().timestamp()
+        for log in logs:
+            if os.stat(log).st_mtime <= t - seconds:
+                os.remove(log)
+
+
+class Rotation:
+    @staticmethod
+    def forward_day(t):
+        return t + datetime_.timedelta(days=1)
+
+    @staticmethod
+    def forward_weekday(t, weekday):
+        while True:
+            t += datetime_.timedelta(days=1)
+            if t.weekday() == weekday:
+                return t
+
+    @staticmethod
+    def forward_interval(t, interval):
+        return t + interval
+
+    @staticmethod
+    def rotation_size(message, file, size_limit):
+        file.seek(0, 2)
+        return file.tell() + len(message) > size_limit
+
+    class RotationTime:
+        def __init__(self, step_forward, time_init=None):
+            self._step_forward = step_forward
+            self._time_init = time_init
+            self._limit = None
+
+        def __call__(self, message, file):
+            if self._limit is None:
+                filepath = os.path.realpath(file.name)
+                creation_time = get_ctime(filepath)
+                set_ctime(filepath, creation_time)
+                start_time = limit = datetime.fromtimestamp(creation_time)
+                if self._time_init is not None:
+                    limit = limit.replace(
+                        hour=self._time_init.hour,
+                        minute=self._time_init.minute,
+                        second=self._time_init.second,
+                        microsecond=self._time_init.microsecond,
+                    )
+                if limit <= start_time:
+                    limit = self._step_forward(limit)
+                self._limit = limit
+
+            record_time = message.record["time"].replace(tzinfo=None)
+            if record_time >= self._limit:
+                while self._limit <= record_time:
+                    self._limit = self._step_forward(self._limit)
+                return True
+            return False
 
 
 class FileSink:
@@ -41,32 +144,25 @@ class FileSink:
         self._kwargs = {**kwargs, "mode": mode, "buffering": buffering, "encoding": self.encoding}
         self._path = str(path)
 
-        self._rotation_function, self._init_rotation = self._make_rotation_function(rotation)
+        self._glob_pattern = self._make_glob_pattern(self._path)
+        self._rotation_function = self._make_rotation_function(rotation)
         self._retention_function = self._make_retention_function(retention)
         self._compression_function = self._make_compression_function(compression)
-        self._glob_pattern = self._make_glob_pattern(self._path)
-        self._get_creation_time = self._make_get_creation_time_function()
-        self._set_creation_time = self._make_set_creation_time_function()
 
         self._file = None
         self._file_path = None
 
         if not delay:
             self._initialize_file(rename_existing=False)
-            if self._init_rotation is not None:
-                self._init_rotation(self._file_path)
 
     def write(self, message):
         if self._file is None:
             self._initialize_file(rename_existing=False)
-            if self._init_rotation is not None:
-                self._init_rotation(self._file_path)
 
         if self._rotation_function is not None and self._rotation_function(message, self._file):
             self._terminate(teardown=True)
             self._initialize_file(rename_existing=True)
-            if self._set_creation_time is not None:
-                self._set_creation_time(self._file_path, datetime.now().timestamp())
+            set_ctime(self._file_path, datetime.now().timestamp())
 
         self._file.write(message)
 
@@ -77,7 +173,7 @@ class FileSink:
         os.makedirs(new_dir, exist_ok=True)
 
         if rename_existing and os.path.isfile(new_path):
-            creation_time = self._get_creation_time(new_path)
+            creation_time = get_ctime(new_path)
             creation_datetime = datetime.fromtimestamp(creation_time)
             date = FileDateFormatter(creation_datetime)
             root, ext = os.path.splitext(new_path)
@@ -99,166 +195,56 @@ class FileSink:
         return pattern
 
     @staticmethod
-    def _make_get_creation_time_function():
-        def get_creation_time_windows(filepath):
-            return os.stat(filepath).st_ctime
-
-        def get_creation_time_darwin(filepath):
-            return os.stat(filepath).st_birthtime
-
-        def get_creation_time_linux(filepath):
-            try:
-                return float(os.getxattr(filepath, b"user.loguru_crtime"))
-            except OSError:
-                return os.stat(filepath).st_mtime
-
-        if os.name == "nt":
-            return get_creation_time_windows
-        elif hasattr(os.stat_result, "st_birthtime"):
-            return get_creation_time_darwin
-        else:
-            return get_creation_time_linux
-
-    @staticmethod
-    def _make_set_creation_time_function():
-        def set_creation_time_darwin(filepath, timestamp):
-            try:
-                os.setxattr(filepath, b"user.loguru_crtime", str(timestamp).encode("ascii"))
-            except OSError:
-                pass
-
-        if os.name == "nt":
-            import win32_setctime
-
-            if win32_setctime.SUPPORTED:
-                return win32_setctime.setctime
-            else:
-                return None
-        elif hasattr(os.stat_result, "st_birthtime"):
-            return None
-        else:
-            return set_creation_time_darwin
-
-    def _make_rotation_function(self, rotation):
-        def make_from_size(size_limit):
-            def rotation_function(message, file):
-                file.seek(0, 2)
-                return file.tell() + len(message) >= size_limit
-
-            return rotation_function, None
-
-        def make_from_time(step_forward, time_init=None):
-
-            time_limit = None
-
-            def init_time_rotation(filepath):
-                nonlocal time_limit
-                creation_time = self._get_creation_time(filepath)
-                if self._set_creation_time is not None:
-                    self._set_creation_time(filepath, creation_time)
-                start_time = time_limit = datetime.fromtimestamp(creation_time)
-                if time_init is not None:
-                    time_limit = time_limit.replace(
-                        hour=time_init.hour,
-                        minute=time_init.minute,
-                        second=time_init.second,
-                        microsecond=time_init.microsecond,
-                    )
-                if time_limit <= start_time:
-                    time_limit = step_forward(time_limit)
-
-            def rotation_function(message, file):
-                nonlocal time_limit
-                record_time = message.record["time"].replace(tzinfo=None)
-                if record_time >= time_limit:
-                    while time_limit <= record_time:
-                        time_limit = step_forward(time_limit)
-                    return True
-                return False
-
-            return rotation_function, init_time_rotation
-
+    def _make_rotation_function(rotation):
         if rotation is None:
-            return None, None
+            return None
         elif isinstance(rotation, str):
             size = string_parsers.parse_size(rotation)
             if size is not None:
-                return self._make_rotation_function(size)
+                return FileSink._make_rotation_function(size)
             interval = string_parsers.parse_duration(rotation)
             if interval is not None:
-                return self._make_rotation_function(interval)
+                return FileSink._make_rotation_function(interval)
             frequency = string_parsers.parse_frequency(rotation)
             if frequency is not None:
-                return make_from_time(frequency)
+                return Rotation.RotationTime(frequency)
             daytime = string_parsers.parse_daytime(rotation)
             if daytime is not None:
                 day, time = daytime
                 if day is None:
-                    return self._make_rotation_function(time)
+                    return FileSink._make_rotation_function(time)
                 if time is None:
                     time = datetime_.time(0, 0, 0)
-
-                def next_day(t):
-                    while True:
-                        t += datetime_.timedelta(days=1)
-                        if t.weekday() == day:
-                            return t
-
-                return make_from_time(next_day, time_init=time)
+                step_forward = partial(Rotation.forward_weekday, weekday=day)
+                return Rotation.RotationTime(step_forward, time)
             raise ValueError("Cannot parse rotation from: '%s'" % rotation)
         elif isinstance(rotation, (numbers.Real, decimal.Decimal)):
-            return make_from_size(rotation)
+            return partial(Rotation.rotation_size, size_limit=rotation)
         elif isinstance(rotation, datetime_.time):
-
-            def next_day(t):
-                return t + datetime_.timedelta(days=1)
-
-            return make_from_time(next_day, time_init=rotation)
+            return Rotation.RotationTime(Rotation.forward_day, rotation)
         elif isinstance(rotation, datetime_.timedelta):
-
-            def add_interval(t):
-                return t + rotation
-
-            return make_from_time(add_interval)
+            step_forward = partial(Rotation.forward_interval, interval=rotation)
+            return Rotation.RotationTime(step_forward)
         elif callable(rotation):
-            return rotation, None
+            return rotation
         else:
             raise ValueError(
                 "Cannot infer rotation for objects of type: '%s'" % type(rotation).__name__
             )
 
-    def _make_retention_function(self, retention):
-        def make_from_filter(filter_logs):
-            def retention_function(logs):
-                for log in filter_logs(logs):
-                    os.remove(log)
-
-            return retention_function
-
+    @staticmethod
+    def _make_retention_function(retention):
         if retention is None:
             return None
         elif isinstance(retention, str):
             interval = string_parsers.parse_duration(retention)
             if interval is None:
                 raise ValueError("Cannot parse retention from: '%s'" % retention)
-            return self._make_retention_function(interval)
+            return FileSink._make_retention_function(interval)
         elif isinstance(retention, int):
-
-            def key_log(log):
-                return (-os.stat(log).st_mtime, log)
-
-            def filter_logs(logs):
-                return sorted(logs, key=key_log)[retention:]
-
-            return make_from_filter(filter_logs)
+            return partial(Retention.retention_count, number=retention)
         elif isinstance(retention, datetime_.timedelta):
-            seconds = retention.total_seconds()
-
-            def filter_logs(logs):
-                t = datetime.now().timestamp()
-                return [log for log in logs if os.stat(log).st_mtime <= t - seconds]
-
-            return make_from_filter(filter_logs)
+            return partial(Retention.retention_age, seconds=retention.total_seconds())
         elif callable(retention):
             return retention
         else:
@@ -266,33 +252,8 @@ class FileSink:
                 "Cannot infer retention for objects of type: '%s'" % type(retention).__name__
             )
 
-    def _make_compression_function(self, compression):
-        def make_compress_generic(opener, **kwargs):
-            def compress(path_in, path_out):
-                with open(path_in, "rb") as f_in:
-                    with opener(path_out, "wb", **kwargs) as f_out:
-                        shutil.copyfileobj(f_in, f_out)
-
-            return compress
-
-        def make_compress_archive(mode):
-            import tarfile
-
-            def compress(path_in, path_out):
-                with tarfile.open(path_out, "w:" + mode) as f_comp:
-                    f_comp.add(path_in, os.path.basename(path_in))
-
-            return compress
-
-        def make_compress_zipped():
-            import zipfile
-
-            def compress(path_in, path_out):
-                with zipfile.ZipFile(path_out, "w", compression=zipfile.ZIP_DEFLATED) as f_comp:
-                    f_comp.write(path_in, os.path.basename(path_in))
-
-            return compress
-
+    @staticmethod
+    def _make_compression_function(compression):
         if compression is None:
             return None
         elif isinstance(compression, str):
@@ -301,51 +262,55 @@ class FileSink:
             if ext == "gz":
                 import gzip
 
-                compress = make_compress_generic(gzip.open)
+                compress = partial(Compression.copy_compress, opener=gzip.open, mode="wb")
             elif ext == "bz2":
                 import bz2
 
-                compress = make_compress_generic(bz2.open)
+                compress = partial(Compression.copy_compress, opener=bz2.open, mode="wb")
+
             elif ext == "xz":
                 import lzma
 
-                compress = make_compress_generic(lzma.open, format=lzma.FORMAT_XZ)
+                compress = partial(
+                    Compression.copy_compress, opener=lzma.open, mode="wb", format=lzma.FORMAT_XZ
+                )
+
             elif ext == "lzma":
                 import lzma
 
-                compress = make_compress_generic(lzma.open, format=lzma.FORMAT_ALONE)
+                compress = partial(
+                    Compression.copy_compress, opener=lzma.open, mode="wb", format=lzma.FORMAT_ALONE
+                )
             elif ext == "tar":
-                compress = make_compress_archive("")
+                import tarfile
+
+                compress = partial(Compression.add_compress, opener=tarfile.open, mode="w:")
             elif ext == "tar.gz":
-                import gzip
+                import tarfile, gzip
 
-                compress = make_compress_archive("gz")
+                compress = partial(Compression.add_compress, opener=tarfile.open, mode="w:gz")
             elif ext == "tar.bz2":
-                import bz2
+                import tarfile, bz2
 
-                compress = make_compress_archive("bz2")
+                compress = partial(Compression.add_compress, opener=tarfile.open, mode="w:bz2")
+
             elif ext == "tar.xz":
-                import lzma
+                import tarfile, lzma
 
-                compress = make_compress_archive("xz")
+                compress = partial(Compression.add_compress, opener=tarfile.open, mode="w:xz")
             elif ext == "zip":
-                compress = make_compress_zipped()
+                import zipfile
+
+                compress = partial(
+                    Compression.write_compress,
+                    opener=zipfile.ZipFile,
+                    mode="w",
+                    compression=zipfile.ZIP_DEFLATED,
+                )
             else:
                 raise ValueError("Invalid compression format: '%s'" % ext)
 
-            def compression_function(path_in):
-                path_out = "{}.{}".format(path_in, ext)
-                if os.path.isfile(path_out):
-                    creation_time = self._get_creation_time(path_out)
-                    creation_datetime = datetime.fromtimestamp(creation_time)
-                    date = FileDateFormatter(creation_datetime)
-                    root, ext_before = os.path.splitext(path_in)
-                    renamed_path = "{}.{}{}.{}".format(root, date, ext_before, ext)
-                    os.rename(path_out, renamed_path)
-                compress(path_in, path_out)
-                os.remove(path_in)
-
-            return compression_function
+            return partial(Compression.compression, ext=ext, compress_function=compress)
         elif callable(compression):
             return compression
         else:

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -17,7 +17,7 @@ class Handler:
     def __init__(
         self,
         *,
-        sink_wrapper,
+        sink,
         name,
         levelno,
         formatter,
@@ -32,9 +32,7 @@ class Handler:
         levels_ansi_codes
     ):
         self._name = name
-        self._sink_wrapper = sink_wrapper
-        self._writer = sink_wrapper.write
-        self._stopper = sink_wrapper.stop
+        self._sink = sink
         self._levelno = levelno
         self._formatter = formatter
         self._is_formatter_dynamic = is_formatter_dynamic
@@ -141,7 +139,7 @@ class Handler:
                 if self._enqueue:
                     self._queue.put(str_record)
                 else:
-                    self._writer(str_record)
+                    self._sink.write(str_record)
 
         except Exception:
             if self._catch:
@@ -155,7 +153,7 @@ class Handler:
             if self._enqueue:
                 self._queue.put(None)
                 self._thread.join()
-            self._stopper()
+            self._sink.stop()
 
     def update_format(self, level_id):
         if not self._colorize or self._is_formatter_dynamic:
@@ -250,7 +248,7 @@ class Handler:
                 message = queue.get()
                 if message is None:
                     break
-                self._writer(message)
+                self._sink.write(message)
             except Exception:
                 if self._catch:
                     if message and hasattr(message, "record"):

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -33,8 +33,13 @@ except ImportError:
 def parse_ansi(color):
     return AnsiMarkup(strip=False).feed(color.strip(), strict=False)
 
-def filter_module(self, record):
-    return (record["name"] + ".")[: self._length] == self._parent
+
+def filter_module(record, parent, length):
+    name = record["name"]
+    if name is None:
+        return False
+    return (name + ".")[: length] == parent
+
 
 def filter_none(record):
     return record["name"] is not None

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -101,15 +101,11 @@ class Core:
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        del state["lock"]
-        try:
-            return pickle.dumps(state)
-        except Exception as e:
-            raise ValueError("The logger can't be pickled") from e
+        state["lock"] = None
+        return state
 
     def __setstate__(self, state):
-        unpickled = pickle.loads(state)
-        self.__dict__.update(unpickled)
+        self.__dict__.update(state)
         self.lock = threading.Lock()
 
 

--- a/loguru/_simple_sinks.py
+++ b/loguru/_simple_sinks.py
@@ -1,7 +1,7 @@
 import logging
 
 
-class StreamSinkWrapper:
+class StreamSink:
     def __init__(self, stream, kwargs):
         self._stream = stream
         self._kwargs = kwargs
@@ -18,7 +18,7 @@ class StreamSinkWrapper:
             self._stream.stop()
 
 
-class StandardSinkWrapper:
+class StandardSink:
     def __init__(self, handler, kwargs, is_formatter_dynamic):
         self._handler = handler
         self._kwargs = kwargs
@@ -50,7 +50,7 @@ class StandardSinkWrapper:
         self._handler.close()
 
 
-class CallableSinkWrapper:
+class CallableSink:
     def __init__(self, function, kwargs):
         self._function = function
         self._kwargs = kwargs

--- a/loguru/_sink_wrappers.py
+++ b/loguru/_sink_wrappers.py
@@ -1,0 +1,62 @@
+import logging
+
+
+class StreamSinkWrapper:
+    def __init__(self, stream, kwargs):
+        self._stream = stream
+        self._kwargs = kwargs
+        self._flushable = hasattr(stream, "flush") and callable(stream.flush)
+        self._stoppable = hasattr(stream, "stop") and callable(stream.stop)
+
+    def write(self, message):
+        self._stream.write(message, **self._kwargs)
+        if self._flushable:
+            self._stream.flush()
+
+    def stop(self):
+        if self._stoppable:
+            self._stream.stop()
+
+
+class StandardSinkWrapper:
+    def __init__(self, handler, kwargs, is_formatter_dynamic):
+        self._handler = handler
+        self._kwargs = kwargs
+        self._is_formatter_dynamic = is_formatter_dynamic
+
+    def write(self, message):
+        record = message.record
+        message = str(message)
+        exc = record["exception"]
+        if not self._is_formatter_dynamic:
+            message = message[:-1]
+        record = logging.root.makeRecord(
+            record["name"],
+            record["level"].no,
+            record["file"].path,
+            record["line"],
+            message,
+            (),
+            (exc.type, exc.value, exc.traceback) if exc else None,
+            record["function"],
+            record["extra"],
+            **self._kwargs
+        )
+        if exc:
+            record.exc_text = "\n"
+        self._handler.handle(record)
+
+    def stop(self):
+        self._handler.close()
+
+
+class CallableSinkWrapper:
+    def __init__(self, function, kwargs):
+        self._function = function
+        self._kwargs = kwargs
+
+    def write(self, message):
+        self._function(message, **self._kwargs)
+
+    def stop(self):
+        pass

--- a/loguru/_string_parsers.py
+++ b/loguru/_string_parsers.py
@@ -2,6 +2,36 @@ import datetime
 import re
 
 
+class Frequencies:
+    @staticmethod
+    def hourly(t):
+        dt = t + datetime.timedelta(hours=1)
+        return dt.replace(minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def daily(t):
+        dt = t + datetime.timedelta(days=1)
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def weekly(t):
+        dt = t + datetime.timedelta(days=7 - t.weekday())
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def monthly(t):
+        if t.month == 12:
+            y, m = t.year + 1, 1
+        else:
+            y, m = t.year, t.month + 1
+        return t.replace(year=y, month=m, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def yearly(t):
+        y = t.year + 1
+        return t.replace(year=y, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
 def parse_size(size):
     size = size.strip()
     reg = re.compile(r"([e\+\-\.\d]+)\s*([kmgtpezy])?(i)?(b)", flags=re.I)
@@ -68,42 +98,19 @@ def parse_frequency(frequency):
 
     if frequency == "hourly":
 
-        def hourly(t):
-            dt = t + datetime.timedelta(hours=1)
-            return dt.replace(minute=0, second=0, microsecond=0)
-
-        return hourly
+        return Frequencies.hourly
     elif frequency == "daily":
 
-        def daily(t):
-            dt = t + datetime.timedelta(days=1)
-            return dt.replace(hour=0, minute=0, second=0, microsecond=0)
-
-        return daily
+        return Frequencies.daily
     elif frequency == "weekly":
 
-        def weekly(t):
-            dt = t + datetime.timedelta(days=7 - t.weekday())
-            return dt.replace(hour=0, minute=0, second=0, microsecond=0)
-
-        return weekly
+        return Frequencies.weekly
     elif frequency == "monthly":
 
-        def monthly(t):
-            if t.month == 12:
-                y, m = t.year + 1, 1
-            else:
-                y, m = t.year, t.month + 1
-            return t.replace(year=y, month=m, day=1, hour=0, minute=0, second=0, microsecond=0)
-
-        return monthly
+        return Frequencies.monthly
     elif frequency == "yearly":
 
-        def yearly(t):
-            y = t.year + 1
-            return t.replace(year=y, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
-
-        return yearly
+        return Frequencies.yearly
 
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,22 +22,9 @@ def check_env_variables():
 
 @pytest.fixture(autouse=True)
 def reset_logger():
-    default_levels = loguru._logger.Logger._levels.copy()
-    default_levels_ansi_codes = loguru._logger.Logger._levels_ansi_codes.copy()
-
     def reset():
         loguru.logger.remove()
-        loguru.logger.__init__(None, 0, False, False, False, False, None, {})
-        loguru._logger.Logger._levels = default_levels.copy()
-        loguru._logger.Logger._levels_ansi_codes = default_levels_ansi_codes.copy()
-        loguru._logger.Logger._min_level = float("inf")
-        loguru._logger.Logger._extra_class = {}
-        loguru._logger.Logger._patcher_class = None
-        loguru._logger.Logger._handlers = {}
-        loguru._logger.Logger._handlers_count = itertools.count()
-        loguru._logger.Logger._enabled = {}
-        loguru._logger.Logger._activation_list = []
-        loguru._logger.Logger._activation_none = True
+        loguru.logger.__init__(loguru._logger.Core(), None, 0, False, False, False, False, None, {})
         logging.Logger.manager.loggerDict.clear()
         logging.root = logging.RootLogger(logging.WARNING)
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -76,7 +76,7 @@ def test_log_before_disable(writer):
 
 
 def test_multiple_activations():
-    n = lambda: len(logger._activation_list)
+    n = lambda: len(logger._core.activation_list)
 
     assert n() == 0
     logger.enable("")

--- a/tests/test_add_option_filter.py
+++ b/tests/test_add_option_filter.py
@@ -39,14 +39,14 @@ def test_filtered_out(filter, writer):
 
 @pytest.mark.parametrize("filter", ["tests", "", lambda _: False])
 def test_filtered_out_f_globals_name_absent(writer, filter, f_globals_name_absent):
-    logger.add(writer, filter=filter, format="{message}")
+    logger.add(writer, filter=filter, format="{message}", catch=False)
     logger.info("It's not ok")
     assert writer.read() == ""
 
 
 @pytest.mark.parametrize("filter", [None, lambda _: True])
 def test_filtered_in_f_globals_name_absent(writer, filter, f_globals_name_absent):
-    logger.add(writer, filter=filter, format="{message}")
+    logger.add(writer, filter=filter, format="{message}", catch=False)
     logger.info("It's ok")
     assert writer.read() == "It's ok\n"
 

--- a/tests/test_add_sinks.py
+++ b/tests/test_add_sinks.py
@@ -123,6 +123,24 @@ def test_flush(rep):
     assert flushed == [expected] * rep
 
 
+def test_file_sink_ascii_encoding(tmpdir):
+    file = tmpdir.join("test.log")
+    logger.add(
+        str(file), encoding="ascii", format="{message}", errors="backslashreplace", catch=False
+    )
+    logger.info("天")
+    logger.remove()
+    assert file.read() == "\\u5929\n"
+
+
+def test_file_sink_utf8_encoding(tmpdir):
+    file = tmpdir.join("test.log")
+    logger.add(str(file), encoding="utf8", format="{message}", errors="strict", catch=False)
+    logger.info("天")
+    logger.remove()
+    assert file.read() == "天\n"
+
+
 def test_disabled_logger_in_sink(sink_with_logger):
     sink = sink_with_logger(logger)
     logger.disable("tests.conftest")

--- a/tests/test_catch_exceptions.py
+++ b/tests/test_catch_exceptions.py
@@ -237,6 +237,38 @@ def test_sink_encoding(writer, encoding):
     assert writer.read().endswith("ZeroDivisionError: division by zero\n")
 
 
+def test_file_sink_ascii_encoding(tmpdir):
+    file = tmpdir.join("test.log")
+    logger.add(str(file), format="", encoding="ascii", errors="backslashreplace", catch=False)
+    a = "天"
+
+    try:
+        "天" * a
+    except Exception:
+        logger.exception("")
+
+    logger.remove()
+    result = file.read()
+    assert result.count('"\\u5929" * a') == 1
+    assert result.count("-> '\\u5929'") == 1
+
+
+def test_file_sink_utf8_encoding(tmpdir):
+    file = tmpdir.join("test.log")
+    logger.add(str(file), format="", encoding="utf8", errors="strict", catch=False)
+    a = "天"
+
+    try:
+        "天" * a
+    except Exception:
+        logger.exception("")
+
+    logger.remove()
+    result = file.read()
+    assert result.count('"天" * a') == 1
+    assert result.count("└ '天'") == 1
+
+
 def test_has_sys_real_prefix(writer, monkeypatch):
     monkeypatch.setattr(sys, "real_prefix", "/foo/bar/baz", raising=False)
     logger.add(writer, backtrace=False, diagnose=True, colorize=False, format="")
@@ -375,6 +407,7 @@ def test_distutils_not_installed(writer, monkeypatch):
         logger.exception("")
 
     assert writer.read().endswith("ZeroDivisionError: division by zero\n")
+
 
 def test_no_exception(writer):
     logger.add(writer, backtrace=False, diagnose=False, colorize=False, format="{message}")

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -1,0 +1,56 @@
+from loguru import logger
+import copy
+
+
+def test_add_sink_after_deepcopy(capsys):
+    logger_ = copy.deepcopy(logger)
+
+    logger_.add(print, format="{message}", end="", catch=False)
+
+    logger_.info("A")
+    logger.info("B")
+
+    out, err = capsys.readouterr()
+    assert out == "A\n"
+    assert err == ""
+
+
+def test_add_sink_before_deepcopy(capsys):
+    logger.add(print, format="{message}", end="", catch=False)
+
+    logger_ = copy.deepcopy(logger)
+
+    logger_.info("A")
+    logger.info("B")
+
+    out, err = capsys.readouterr()
+    assert out == "A\nB\n"
+    assert err == ""
+
+
+def test_remove_from_original(capsys):
+    logger.add(print, format="{message}", end="", catch=False)
+
+    logger_ = copy.deepcopy(logger)
+    logger.remove()
+
+    logger_.info("A")
+    logger.info("B")
+
+    out, err = capsys.readouterr()
+    assert out == "A\n"
+    assert err == ""
+
+
+def test_remove_from_copy(capsys):
+    logger.add(print, format="{message}", end="", catch=False)
+
+    logger_ = copy.deepcopy(logger)
+    logger_.remove()
+
+    logger_.info("A")
+    logger.info("B")
+
+    out, err = capsys.readouterr()
+    assert out == "B\n"
+    assert err == ""

--- a/tests/test_filesink_compression.py
+++ b/tests/test_filesink_compression.py
@@ -71,7 +71,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     logger.debug("test")
 
     filesink = next(iter(logger._core.handlers.values()))._sink_wrapper._stream
-    monkeypatch.setattr(filesink, "_get_creation_time", creation_time)
+    monkeypatch.setattr(loguru._file_sink, "get_ctime", creation_time)
 
     logger.remove(j)
 

--- a/tests/test_filesink_compression.py
+++ b/tests/test_filesink_compression.py
@@ -70,7 +70,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     j = logger.add(str(tmpdir.join("test.log")), compression="tar.gz")
     logger.debug("test")
 
-    filesink = next(iter(logger._handlers.values()))._writer.__self__
+    filesink = next(iter(logger._core.handlers.values()))._writer.__self__
     monkeypatch.setattr(filesink, "_get_creation_time", creation_time)
 
     logger.remove(j)

--- a/tests/test_filesink_compression.py
+++ b/tests/test_filesink_compression.py
@@ -70,7 +70,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     j = logger.add(str(tmpdir.join("test.log")), compression="tar.gz")
     logger.debug("test")
 
-    filesink = next(iter(logger._core.handlers.values()))._sink_wrapper._stream
+    filesink = next(iter(logger._core.handlers.values()))._sink
     monkeypatch.setattr(loguru._file_sink, "get_ctime", creation_time)
 
     logger.remove(j)

--- a/tests/test_filesink_compression.py
+++ b/tests/test_filesink_compression.py
@@ -70,7 +70,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     j = logger.add(str(tmpdir.join("test.log")), compression="tar.gz")
     logger.debug("test")
 
-    filesink = next(iter(logger._core.handlers.values()))._writer.__self__
+    filesink = next(iter(logger._core.handlers.values()))._sink_wrapper._stream
     monkeypatch.setattr(filesink, "_get_creation_time", creation_time)
 
     logger.remove(j)

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -421,7 +421,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     i = logger.add(str(tmpdir.join("test.log")), rotation=10, format="{message}")
     logger.debug("X")
 
-    filesink = next(iter(logger._handlers.values()))._writer.__self__
+    filesink = next(iter(logger._core.handlers.values()))._writer.__self__
     monkeypatch.setattr(filesink, "_get_creation_time", creation_time)
 
     logger.debug("Y" * 20)

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -421,7 +421,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     i = logger.add(str(tmpdir.join("test.log")), rotation=10, format="{message}")
     logger.debug("X")
 
-    filesink = next(iter(logger._core.handlers.values()))._writer.__self__
+    filesink = next(iter(logger._core.handlers.values()))._sink_wrapper._stream
     monkeypatch.setattr(filesink, "_get_creation_time", creation_time)
 
     logger.debug("Y" * 20)

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -426,7 +426,7 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     i = logger.add(str(tmpdir.join("test.log")), rotation=10, format="{message}")
     logger.debug("X")
 
-    filesink = next(iter(logger._core.handlers.values()))._sink_wrapper._stream
+    filesink = next(iter(logger._core.handlers.values()))._sink
     monkeypatch.setattr(loguru._file_sink, "get_ctime", creation_time)
 
     logger.debug("Y" * 20)

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,409 @@
+import os
+import sys
+import multiprocessing
+import loguru
+from loguru import logger
+import time
+import pytest
+
+
+def do_something(i):
+    logger.info("#{}", i)
+
+
+def set_logger(logger_):
+    global logger
+    logger = logger_
+
+
+def subworker(logger_):
+    logger_.info("Child")
+
+
+def subworker_inheritance():
+    logger.info("Child")
+
+
+def subworker_remove(logger_):
+    logger_.info("Child")
+    logger_.remove()
+    logger_.info("Nope")
+
+
+def subworker_remove_inheritance():
+    logger.info("Child")
+    logger.remove()
+    logger.info("Nope")
+
+
+def subworker_barrier(logger_, barrier):
+    logger_.info("Child")
+    barrier.wait()
+    time.sleep(0.5)
+    logger_.info("Nope")
+
+
+def subworker_barrier_inheritance(barrier):
+    logger.info("Child")
+    barrier.wait()
+    time.sleep(0.5)
+    logger.info("Nope")
+
+
+class Writer:
+    def __init__(self):
+        self._output = ""
+
+    def write(self, message):
+        self._output += message
+
+    def read(self):
+        return self._output
+
+
+def test_apply_spawn(monkeypatch):
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(loguru._handler, "multiprocessing", ctx)
+
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    with ctx.Pool(1, set_logger, [logger]) as pool:
+        for i in range(3):
+            pool.apply(do_something, (i,))
+        pool.close()
+        pool.join()
+
+    logger.info("Done!")
+    logger.remove()
+
+    assert writer.read() == "#0\n#1\n#2\nDone!\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_apply_fork():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    with multiprocessing.Pool(1, set_logger, [logger]) as pool:
+        for i in range(3):
+            pool.apply(do_something, (i,))
+        pool.close()
+        pool.join()
+
+    logger.info("Done!")
+    logger.remove()
+
+    assert writer.read() == "#0\n#1\n#2\nDone!\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_apply_inheritance():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    with multiprocessing.Pool(1) as pool:
+        for i in range(3):
+            pool.apply(do_something, (i,))
+        pool.close()
+        pool.join()
+
+    logger.info("Done!")
+    logger.remove()
+
+    assert writer.read() == "#0\n#1\n#2\nDone!\n"
+
+
+def test_apply_async_spawn(monkeypatch):
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(loguru._handler, "multiprocessing", ctx)
+
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    with ctx.Pool(1, set_logger, [logger]) as pool:
+        for i in range(3):
+            result = pool.apply_async(do_something, (i,))
+            result.get()
+        pool.close()
+        pool.join()
+
+    logger.info("Done!")
+    logger.remove()
+
+    assert writer.read() == "#0\n#1\n#2\nDone!\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_apply_async_fork():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    with multiprocessing.Pool(1, set_logger, [logger]) as pool:
+        for i in range(3):
+            result = pool.apply_async(do_something, (i,))
+            result.get()
+        pool.close()
+        pool.join()
+
+    logger.info("Done!")
+    logger.remove()
+
+    assert writer.read() == "#0\n#1\n#2\nDone!\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_apply_async_inheritance():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    with multiprocessing.Pool(1) as pool:
+        for i in range(3):
+            result = pool.apply_async(do_something, (i,))
+            result.get()
+        pool.close()
+        pool.join()
+
+    logger.info("Done!")
+    logger.remove()
+
+    assert writer.read() == "#0\n#1\n#2\nDone!\n"
+
+
+def test_process_spawn(monkeypatch):
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(loguru._handler, "multiprocessing", ctx)
+
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = ctx.Process(target=subworker, args=(logger,))
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_process_fork():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker, args=(logger,))
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_process_inheritance():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker_inheritance)
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+def test_remove_in_child_process_spawn(monkeypatch):
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(loguru._handler, "multiprocessing", ctx)
+
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = ctx.Process(target=subworker_remove, args=(logger,))
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_remove_in_child_process_fork():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker_remove, args=(logger,))
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_remove_in_child_process_inheritance():
+    writer = Writer()
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker_remove_inheritance)
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+def test_remove_in_main_process_spawn(monkeypatch):
+    # Actually, this test may fail if sleep time in main process is too small (and no barrier used)
+    # In such situation, it seems the child process has not enough time to initialize itself
+    # It may fail with an "EOFError" during unpickling of the (garbage collected / closed) Queue
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(loguru._handler, "multiprocessing", ctx)
+
+    writer = Writer()
+    barrier = ctx.Barrier(2)
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = ctx.Process(target=subworker_barrier, args=(logger, barrier))
+    process.start()
+    barrier.wait()
+    logger.info("Main")
+    logger.remove()
+    process.join()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_remove_in_main_process_fork():
+    writer = Writer()
+    barrier = multiprocessing.Barrier(2)
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker_barrier, args=(logger, barrier))
+    process.start()
+    barrier.wait()
+    logger.info("Main")
+    logger.remove()
+    process.join()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_remove_in_main_process_inheritance():
+    writer = Writer()
+    barrier = multiprocessing.Barrier(2)
+
+    logger.add(writer, format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker_barrier_inheritance, args=(barrier,))
+    process.start()
+    barrier.wait()
+    logger.info("Main")
+    logger.remove()
+    process.join()
+
+    assert writer.read() == "Child\nMain\n"
+
+
+def test_not_picklable_sinks_spawn(monkeypatch, tmpdir, capsys):
+    ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(loguru._handler, "multiprocessing", ctx)
+
+    filepath = tmpdir.join("test.log")
+    stream = sys.stderr
+    output = []
+
+    logger.add(str(filepath), format="{message}", enqueue=True)
+    logger.add(stream, format="{message}", enqueue=True)
+    logger.add(lambda m: output.append(m), format="{message}", enqueue=True)
+
+    process = ctx.Process(target=subworker, args=[logger])
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    out, err = capsys.readouterr()
+
+    assert filepath.read() == "Child\nMain\n"
+    assert out == ""
+    assert err == "Child\nMain\n"
+    assert output == ["Child\n", "Main\n"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_not_picklable_sinks_fork(capsys, tmpdir):
+    filepath = tmpdir.join("test.log")
+    stream = sys.stderr
+    output = []
+
+    logger.add(str(filepath), format="{message}", enqueue=True)
+    logger.add(stream, format="{message}", enqueue=True)
+    logger.add(lambda m: output.append(m), format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker, args=[logger])
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    out, err = capsys.readouterr()
+
+    assert filepath.read() == "Child\nMain\n"
+    assert out == ""
+    assert err == "Child\nMain\n"
+    assert output == ["Child\n", "Main\n"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
+def test_not_picklable_sinks_inheritance(capsys, tmpdir):
+    filepath = tmpdir.join("test.log")
+    stream = sys.stderr
+    output = []
+
+    logger.add(str(filepath), format="{message}", enqueue=True)
+    logger.add(stream, format="{message}", enqueue=True)
+    logger.add(lambda m: output.append(m), format="{message}", enqueue=True)
+
+    process = multiprocessing.Process(target=subworker_inheritance)
+    process.start()
+    process.join()
+
+    logger.info("Main")
+    logger.remove()
+
+    out, err = capsys.readouterr()
+
+    assert filepath.read() == "Child\nMain\n"
+    assert out == ""
+    assert err == "Child\nMain\n"
+    assert output == ["Child\n", "Main\n"]

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -180,7 +180,7 @@ def test_pickling_no_handler(writer):
 
 def test_pickling_handler_not_serializable():
     logger.add(lambda m: None)
-    with pytest.raises(ValueError, match="The logger can't be pickled"):
+    with pytest.raises((pickle.PicklingError, AttributeError), match="Can't (pickle|get local)"):
         pickle.dumps(logger)
 
 
@@ -218,13 +218,13 @@ def test_pickling_format_function(capsys):
 
 def test_pickling_filter_function_not_serializable():
     logger.add(print, filter=lambda r: True)
-    with pytest.raises(ValueError, match="The logger can't be pickled"):
+    with pytest.raises((pickle.PicklingError, AttributeError), match="Can't (pickle|get local)"):
         pickle.dumps(logger)
 
 
 def test_pickling_format_function_not_serializable():
     logger.add(print, format=lambda r: "{message}")
-    with pytest.raises(ValueError, match="The logger can't be pickled"):
+    with pytest.raises((pickle.PicklingError, AttributeError), match="Can't (pickle|get local)"):
         pickle.dumps(logger)
 
 

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -87,7 +87,7 @@ def test_pickling_stream_handler(flushable, stoppable):
     pickled = pickle.dumps(logger)
     unpickled = pickle.loads(pickled)
     unpickled.debug("A message")
-    stream = next(iter(unpickled._core.handlers.values()))._sink_wrapper._stream
+    stream = next(iter(unpickled._core.handlers.values()))._sink._stream
     unpickled.remove(i)
     assert stream.wrote == "DEBUG - test_pickling_stream_handler - A message\n"
     assert stream.flushed == flushable
@@ -100,7 +100,7 @@ def test_pickling_standard_handler():
     pickled = pickle.dumps(logger)
     unpickled = pickle.loads(pickled)
     unpickled.debug("A message")
-    handler = next(iter(unpickled._core.handlers.values()))._sink_wrapper._handler
+    handler = next(iter(unpickled._core.handlers.values()))._sink._handler
     assert handler.written == "DEBUG - test_pickling_standard_handler - A message"
 
 
@@ -109,7 +109,7 @@ def test_pickling_class_handler():
     pickled = pickle.dumps(logger)
     unpickled = pickle.loads(pickled)
     unpickled.debug("A message")
-    stream = next(iter(unpickled._core.handlers.values()))._sink_wrapper._stream
+    stream = next(iter(unpickled._core.handlers.values()))._sink._stream
     assert stream.wrote == "DEBUG - test_pickling_class_handler - A message\n"
 
 

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -4,23 +4,30 @@ import sys
 import pytest
 
 
-def test_pickling_logging_method(writer):
-    logger.add(writer, format="{level} - {function} - {message}")
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_pickling_logging_method(capsys):
+    logger.add(print, format="{level} - {function} - {message}")
     pickled = pickle.dumps(logger.critical)
     func = pickle.loads(pickled)
     func("A message")
-    assert writer.read() == "CRITICAL - test_pickling_logging_method - A message\n"
+    out, err = capsys.readouterr()
+    assert out == "CRITICAL - test_pickling_logging_method - A message\n"
+    assert err == ""
 
 
-def test_pickling_log_method(writer):
-    logger.add(writer, format="{level} - {function} - {message}")
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_pickling_log_method(capsys):
+    logger.add(print, format="{level} - {function} - {message}")
     pickled = pickle.dumps(logger.log)
     func = pickle.loads(pickled)
     func(19, "A message")
-    assert writer.read() == "Level 19 - test_pickling_log_method - A message\n"
+    out, err = capsys.readouterr()
+    assert out == "Level 19 - test_pickling_log_method - A message\n"
+    assert err == ""
 
 
-def test_pickling_logger(writer):
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_pickling_logger_no_handler(writer):
     pickled = pickle.dumps(logger)
     inst = pickle.loads(pickled)
     inst.add(writer, format="{level} - {function} - {message}")
@@ -28,6 +35,25 @@ def test_pickling_logger(writer):
     assert writer.read() == "DEBUG - test_pickling_logger - A message\n"
 
 
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_pickling_logger_handler_serializable(capsys):
+    logger.add(print)
+    pickled = pickle.dumps(logger)
+    inst = pickle.loads(pickled)
+    inst.debug("A message")
+    out, err = capsys.readouterr()
+    assert out == "DEBUG - test_pickling_logger - A message\n"
+    assert err == ""
+
+
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_pickling_logger_handler_not_serializable():
+    logger.add(lambda m: None)
+    with pytest.raises(ValueError, match="The logger can't be pickled"):
+        pickle.dumps(logger)
+
+
+@pytest.mark.xfail(reason="Not yet implemented")
 @pytest.mark.parametrize(
     "method",
     [


### PR DESCRIPTION
This required a whole refactoring of the internal structure of `logger`. Added handler were previously stored as class attributes. Making them instance attributes allow them to be inherited while creating child processes on Windows. 

The refactoring also removed all closure function causing the `logger` to not be picklable. This means the `logger` can now be deepcopied, resulting in seperate loggers to which handlers can be added independently if needed.