### PR TITLE
Expect an AttributeError on os.getxattr / os.setxattr

### DIFF
--- a/loguru/_ctime_functions.py
+++ b/loguru/_ctime_functions.py
@@ -25,11 +25,11 @@ else:
     def get_ctime(filepath):
         try:
             return float(os.getxattr(filepath, b"user.loguru_crtime"))
-        except OSError, AttributeError:
+        except (OSError, AttributeError):
             return os.stat(filepath).st_mtime
 
     def set_ctime(filepath, timestamp):
         try:
             os.setxattr(filepath, b"user.loguru_crtime", str(timestamp).encode("ascii"))
-        except OSError, AttributeError:
+        except (OSError, AttributeError):
             pass

--- a/loguru/_ctime_functions.py
+++ b/loguru/_ctime_functions.py
@@ -25,11 +25,11 @@ else:
     def get_ctime(filepath):
         try:
             return float(os.getxattr(filepath, b"user.loguru_crtime"))
-        except OSError:
+        except OSError, AttributeError:
             return os.stat(filepath).st_mtime
 
     def set_ctime(filepath, timestamp):
         try:
             os.setxattr(filepath, b"user.loguru_crtime", str(timestamp).encode("ascii"))
-        except OSError:
+        except OSError, AttributeError:
             pass


### PR DESCRIPTION
Some distributions (notably alpine) don't have these functions implemented, and calling them causes an AttributeError. I'm just adding those to the expected errors to be thrown, since there's a fallback in place for when xattr fails. 