### PR TITLE
Expose StrRecord in Public API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@
 - Add the level ``name`` as the first argument of namedtuple returned by the ``.level()`` method.
 - Replace ``ValueError`` with ``TypeError`` for exceptions raised when a ``logger`` method was called with argument of invalid type.
 - Remove inheritance of some record dict attributes to ``str`` (for ``"level"``, ``"file"``, ``"thread"`` and ``"process"``).
+- Expose ``StrRecord`` in the public API so that custom sink functions may be properly typed.
 
 
 `0.3.2`_ (2019-07-21)

--- a/docs/api/strrecord.rst
+++ b/docs/api/strrecord.rst
@@ -1,0 +1,7 @@
+loguru.StrRecord
+================
+
+.. automodule:: loguru._handler
+
+.. autoclass:: loguru._handler.StrRecord()
+   :members:

--- a/loguru/__init__.py
+++ b/loguru/__init__.py
@@ -8,6 +8,7 @@ import sys as _sys
 
 from . import _defaults
 from ._logger import Logger as _Logger, Core as _Core
+from ._handler import StrRecord
 
 __version__ = "0.3.2"
 

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -10,6 +10,15 @@ from ._ansimarkup import AnsiMarkup
 
 
 class StrRecord(str):
+    """
+    A record to be logged.
+
+    This type is a subclass of |str| and may be used as such in cased where the formatted
+    message is desired.
+
+    Instances of ``StrRecord`` have an attribute ``record`` which is a |dict| containing all 
+    contextual information possibly needed.
+    """
     __slots__ = ("record",)
 
 

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -329,8 +329,9 @@ class Logger:
           method, it will be automatically called at sink termination.
         - A file path as |str| or |Path|. It can be parametrized with some additional parameters,
           see below.
-        - A simple |function|_ like ``lambda msg: print(msg)``. This allows for logging
-          procedure entirely defined by user preferences and needs.
+        - A simple |function|_ like ``lambda msg: print(msg)``. Will be called with one positional
+          argument of type |StrRecord|. This allows for logging procedure entirely defined by user
+          preferences and needs.
         - A built-in |Handler| like ``logging.StreamHandler``. In such a case, the `Loguru` records
           are automatically converted to the structure expected by the |logging| module.
 
@@ -341,9 +342,10 @@ class Logger:
 
         .. rubric:: The logged message
 
-        The logged message passed to all added sinks is nothing more than a string of the
-        formatted log, to which a special attribute is associated: the ``.record`` which is a dict
-        containing all contextual information possibly needed (see below).
+        The logged message passed to all added sinks is a |StrRecord|. |StrRecord| subclasses from 
+        |str| and may be used as such to access the formatted log message. For more fine-grained
+        control, the ``record`` attribute may be accessed for a dict containing all contextual
+        information possibly needed (see below).
 
         Logged messages are formatted according to the ``format`` of the added sink. This format
         is usually a string containing braces fields to display attributes from the record dict.


### PR DESCRIPTION
I have a custom logging need (sending records to an HTTP API in another thread), so the `CallableSink` seemed pretty attractive to me.

To do my custom logic, I need access to the log record's contextual information, such as level, message, etc, . Thankfully, the argument passed to a `CallableSink` is a `StrRecord` that has a `record` attribute that has all this data as a dict.

However, I can't type hint this argument properly because `StrRecord` is not exposed from the loguru API (it's in a `_`-prefixed package, `loguru._handler.StrRecord`). Therefore, I can't really know if I can access the `record` attribute. So I'm forced to make a leap of faith and hint it as `Any`.

My primary request is that `StrRecord` is exposed from the loguru API so I can safely access the `record` attribute. I think this is reasonable, if not necessary, considering that they're passed to user code and is also [a documented feature](https://loguru.readthedocs.io/en/stable/api/logger.html#message).

- [x] Expose `StrRecord` in public API
- [x] Create `StrRecord` docstring
- [x] Create documentation page for `StrRecord`
- [x] Reference `StrRecord` in docs where appropriate
- [x] Add change to `CHANGELOG.rst`

**I definitely need some review on my docstring and Sphinx formatting and style.**

### Versions
loguru version `0.3.2`
Python version `3.8.0`
Windows 10, 64-bit