### PR TITLE
Give queue worker thread a name.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@
 - Add the level ``name`` as the first argument of namedtuple returned by the ``.level()`` method.
 - Replace ``ValueError`` with ``TypeError`` for exceptions raised when a ``logger`` method was called with argument of invalid type.
 - Remove inheritance of some record dict attributes to ``str`` (for ``"level"``, ``"file"``, ``"thread"`` and ``"process"``).
-
+- Give queue worker thread a name.
 
 `0.3.2`_ (2019-07-21)
 =====================

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -68,7 +68,7 @@ class Handler:
             self._thread = threading.Thread(
                 target=self._queued_writer,
                 daemon=True,
-                name="loguru-writer"
+                name="loguru-writer-%d" % self._id
             )
             self._thread.start()
 

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -65,7 +65,11 @@ class Handler:
         if self._enqueue:
             self._owner_process = multiprocessing.current_process()
             self._queue = multiprocessing.SimpleQueue()
-            self._thread = threading.Thread(target=self._queued_writer, daemon=True)
+            self._thread = threading.Thread(
+                target=self._queued_writer,
+                daemon=True,
+                name="loguru-writer"
+            )
             self._thread.start()
 
     def __repr__(self):


### PR DESCRIPTION
Hey @Delgan,

I'm doing some debugging with a multi-threaded application and also have a Loguru sink with `enqueue=True`. (As we've discussed before) this instructs Loguru to manage a thread that processes a queue of log records.

Currently, that thread's name is the default one:
> By default, a unique name is constructed of the form “Thread-N” where N is a small decimal number.

_[https://docs.python.org/3.8/library/threading.html#threading.Thread](https://docs.python.org/3.8/library/threading.html#threading.Thread)_

For identification purposes, it'd be helpful to see a descriptive name for this thread in environments/debuggers/etc that support listing threads.

The name I've chosen `loguru-writer`.

This doesn't affect the operation of the Loguru in any other way:

> [The name is] A string used for identification purposes only. It has no semantics.

_[https://docs.python.org/3.8/library/threading.html#threading.Thread.name](https://docs.python.org/3.8/library/threading.html#threading.Thread.name)_

- [x] Give queue worker thread a name.
- [x] Add change to CHANGELOG.rst.
- [x] Tox passes.