### PR TITLE
Handle quoted environment variables from Windows 10

### DIFF
--- a/loguru/_defaults.py
+++ b/loguru/_defaults.py
@@ -1,3 +1,4 @@
+import os
 from os import environ
 
 
@@ -6,6 +7,8 @@ def env(key, type_, default=None):
         return default
 
     val = environ[key]
+    if os.name=="nt":
+        val=val.replace('"', '')
 
     if type_ == str:
         return val


### PR DESCRIPTION
To set an environment with < in Windows 10 must be quoted with ", for example 
set LOGURU_CRITICAL_COLOR="<RED><bold>"

However, os.environ("LOGURU_CRITICAL_COLOR") would return '"<RED><bold>"'.  The changes replace the outermost single quotes.