### PR TITLE
Allow .opt() calls to be chained on loggers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+`Unreleased`_
+=============
+- Allow calling ``.opt()`` multiple times, retaining the values set each time (`#192 <https://github.com/Delgan/loguru/issues/192>`_).
+
+
 `0.4.0`_ (2019-12-02)
 =====================
 

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -118,6 +118,8 @@ start_time = aware_now()
 
 context = ContextVar("loguru_context", default={})
 
+_UNSET = object()
+
 
 class Core:
     def __init__(self):
@@ -1156,7 +1158,7 @@ class Logger:
 
         return Catcher(False)
 
-    def opt(self, *, exception=None, record=False, lazy=False, ansi=False, raw=False, depth=0):
+    def opt(self, *, exception=_UNSET, record=_UNSET, lazy=_UNSET, ansi=_UNSET, raw=_UNSET, depth=_UNSET):
         r"""Parametrize a logging call to slightly change generated log message.
 
         Parameters
@@ -1222,7 +1224,11 @@ class Logger:
         >>> func()
         [18:11:54] DEBUG in 'func' - Get parent context
         """
-        return Logger(self._core, exception, depth, record, lazy, ansi, raw, *self._options[-2:])
+        options = list(self._options)
+        for i, opt in enumerate((exception, depth, record, lazy, ansi, raw)):
+            if opt is not _UNSET:
+                options[i] = opt
+        return Logger(self._core, *options)
 
     def bind(__self, **kwargs):
         """Bind attributes to the ``extra`` dict of each logged message record.

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -357,3 +357,10 @@ def test_before_bind(writer):
     logger.add(writer, format="{message}")
     logger.opt(record=True).bind(key="value").info("{record[level]}")
     assert writer.read() == "INFO\n"
+
+
+@pytest.mark.parametrize("colorize", [True, False])
+def test_raw_with_ansi(writer, colorize):
+    logger.add(writer, format="XYZ", colorize=colorize)
+    logger.opt(raw=True).opt(ansi=True).info("Raw <red>colors</red> and <lvl>level</lvl>")
+    assert writer.read() == parse("Raw <red>colors</red> and <b>level</b>", colorize=colorize)


### PR DESCRIPTION
This addresses issue #192 
Calling .opt() multiple times now keeps the options set on previous calls rather than setting all unspecified options back to their default.

Wasn't sure best how to make the test for this, so I just copied another one that used multiple options, and split it apart into 2 `.opt()` calls.