### PR TITLE
Fix removing simple queue in child processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # VScode
 .vscode/
+
+# Idea IDE
+.idea/


### PR DESCRIPTION
Hello, I think this pull request could fix https://github.com/Delgan/loguru/issues/309.

There is problem with calling `multiprocessing.current_process()` which returns the instance of `_MainProcess()`. But because this code is executed before a new thread there are same values/objects. In child process is the same object as in parent process. You can check it with `id(self._owner_process)`.

Source code of multiprocessing: https://github.com/python/cpython/blob/master/Lib/multiprocessing/process.py#L41

Another way how to fix it is to move `self._owner_process = multiprocessing.current_process()` after creating a new thread. There would be different objects in every process. But I think there is better to work wih PID numbers than objects.

