### PR TITLE
Fix typos on error messages and some documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,7 +82,7 @@
 `0.3.1`_ (2019-07-13)
 =====================
 
-- Fix ``retention`` and ``rotation`` issues when file sink initiliazed with ``delay=True`` (`#113 <https://github.com/Delgan/loguru/issues/113>`_).
+- Fix ``retention`` and ``rotation`` issues when file sink initialized with ``delay=True`` (`#113 <https://github.com/Delgan/loguru/issues/113>`_).
 - Fix ``"sec"`` no longer recognized as a valid duration unit for file ``rotation`` and ``retention`` arguments.
 - Ensure stack from the caller is displayed while formatting exception of a function decorated with ``@logger.catch`` when ``backtrace=False``.
 - Modify datetime used to automatically rename conflicting file when rotating (it happens if file already exists because ``"{time}"`` not presents in filename) so it's based on the file creation time rather than the current time.

--- a/docs/resources/recipes.rst
+++ b/docs/resources/recipes.rst
@@ -739,7 +739,7 @@ Things get a little more complicated on Windows. Indeed, this operating system d
 
 Windows requires the added sinks to be picklable or otherwise will raise an error while creating the child process. Many stream objects like standard output and file descriptors are not picklable. In such case, the ``enqueue=True`` argument is required as it will allow the child process to only inherit the queue object where logs are sent.
 
-The |multiprocessing| library is also commonly used to start a pool of workers using for example |Pool.map| or |Pool.apply|. Again, it will work flawlessly on Linux, but it will require some tinkering on Windows. You will probably not be able to pass the ``logger`` as an argument for your worker functions because it needs to be picklable, but altough handlers added using ``enqueue=True`` are "inheritable", they are not "picklable". Instead, you will need to make use of the ``initializer`` and ``initargs`` parameters while creating the |Pool| object in a way allowing your workers to access the shared ``logger``. You can either assign it to a class attribute or override the global logger of your child processes:
+The |multiprocessing| library is also commonly used to start a pool of workers using for example |Pool.map| or |Pool.apply|. Again, it will work flawlessly on Linux, but it will require some tinkering on Windows. You will probably not be able to pass the ``logger`` as an argument for your worker functions because it needs to be picklable, but although handlers added using ``enqueue=True`` are "inheritable", they are not "picklable". Instead, you will need to make use of the ``initializer`` and ``initargs`` parameters while creating the |Pool| object in a way allowing your workers to access the shared ``logger``. You can either assign it to a class attribute or override the global logger of your child processes:
 
 .. code::
 
@@ -785,7 +785,7 @@ The |multiprocessing| library is also commonly used to start a pool of workers u
 
         worker = workers_a.Worker()
         with Pool(4, initializer=worker.set_logger, initargs=(logger, )) as pool:
-            resuts = pool.map(worker.work, [1, 10, 100])
+            results = pool.map(worker.work, [1, 10, 100])
 
         with Pool(4, initializer=workers_b.set_logger, initargs=(logger, )) as pool:
             results = pool.map(workers_b.work, [1, 10, 100])

--- a/loguru/__init__.pyi
+++ b/loguru/__init__.pyi
@@ -73,8 +73,8 @@ listed here and might be useful to type hint your code:
 - ``RecordException``: the ``record["exception"]`` with ``type``, ``value`` and ``traceback``
   attributes.
 
-If that is not enough, one can also use the |loguru-mypy|_ library developped by `@kornicameister`_.
-Plugin can be installed seperately using::
+If that is not enough, one can also use the |loguru-mypy|_ library developed by `@kornicameister`_.
+Plugin can be installed separately using::
 
     pip install loguru-mypy
 

--- a/loguru/_colorizer.py
+++ b/loguru/_colorizer.py
@@ -251,7 +251,7 @@ class AnsiParser:
 
                 if ansi is None:
                     raise ValueError(
-                        'Tag "%s" does not corespond to any known ansi directive, '
+                        'Tag "%s" does not correspond to any known ansi directive, '
                         "make sure you did not misspelled it (or prepend '\\' to escape it)"
                         % markup
                     )

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -865,7 +865,7 @@ class Logger:
                 if levelno_ < 0:
                     raise ValueError(
                         "The filter dict contains a module '%s' associated to an invalid level, "
-                        "it should be a positive interger, not: '%d'" % (module, levelno_)
+                        "it should be a positive integer, not: '%d'" % (module, levelno_)
                     )
                 level_per_module[module] = levelno_
             filter_func = functools.partial(

--- a/tests/exceptions/output/others/catch_message.txt
+++ b/tests/exceptions/output/others/catch_message.txt
@@ -1,11 +1,11 @@
-An error occured (1):
+An error occurred (1):
 Traceback (most recent call last):
   File "tests/exceptions/source/others/catch_message.py", line 14, in <module>
     a()
   File "tests/exceptions/source/others/catch_message.py", line 10, in a
     1 / 0
 ZeroDivisionError: division by zero
-An error occured (2):
+An error occurred (2):
 Traceback (most recent call last):
   File "tests/exceptions/source/others/catch_message.py", line 17, in <module>
     a()

--- a/tests/exceptions/source/others/catch_message.py
+++ b/tests/exceptions/source/others/catch_message.py
@@ -10,8 +10,8 @@ def a():
     1 / 0
 
 
-with logger.catch(message="An error occured (1):"):
+with logger.catch(message="An error occurred (1):"):
     a()
 
-a = logger.catch(message="An error occured (2):")(a)
+a = logger.catch(message="An error occurred (2):")(a)
 a()


### PR DESCRIPTION
Fixed some typo on `_logger.pu` and took time to check for more typos and fixing them.