### PR TITLE
Fixed code style and flake8 errors.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,7 @@
-`0.5.4`_ (2020-10-24)
-=====================
+`_Unreleased`_
+==============
 
-- Fix flake8 errors in tests/, docs/ and setup.py (`#353 <https://github.com/Delgan/loguru/issues/353>`_).
-- Optimize _Logger initialization reading using key/value style (`#353 <https://github.com/Delgan/loguru/issues/353>`_).
+- Fix ``flake8`` errors and improve code readability (`#353 <https://github.com/Delgan/loguru/issues/353>`_, thanks `@AndrewYakimets <https://github.com/AndrewYakimets>`_).
 
 
 `0.5.3`_ (2020-09-20)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+`0.5.4`_ (2020-10-24)
+=====================
+
+- Fix flake8 errors in tests/, docs/ and setup.py (`#353 <https://github.com/Delgan/loguru/issues/353>`_).
+- Optimize _Logger initialization reading using key/value style (`#353 <https://github.com/Delgan/loguru/issues/353>`_).
+
+
 `0.5.3`_ (2020-09-20)
 =====================
 

--- a/docs/_extensions/autodoc_stub_file.py
+++ b/docs/_extensions/autodoc_stub_file.py
@@ -15,7 +15,6 @@ into account: ``make clean && make html``.
 import os
 import sys
 import types
-import code
 
 
 def get_module_docstring(filepath):

--- a/loguru/__init__.py
+++ b/loguru/__init__.py
@@ -14,7 +14,16 @@ __version__ = "0.5.3"
 
 __all__ = ["logger"]
 
-logger = _Logger(_Core(), None, 0, False, False, False, False, True, None, {})
+logger = _Logger(core=_Core(),
+                 exception=None,
+                 depth=0,
+                 record=False,
+                 lazy=False,
+                 colors=False,
+                 raw=False,
+                 capture=True,
+                 patcher=None,
+                 extra={})
 
 if _defaults.LOGURU_AUTOINIT and _sys.stderr:
     logger.add(_sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,8 @@ import asyncio
 import contextlib
 import loguru
 import logging
-import itertools
 import pytest
 import os
-import subprocess
 import sys
 import time
 import warnings

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -76,7 +76,8 @@ def test_log_before_disable(writer):
 
 
 def test_multiple_activations():
-    n = lambda: len(logger._core.activation_list)
+    def n():
+        return len(logger._core.activation_list)
 
     assert n() == 0
     logger.enable("")

--- a/tests/test_add_option_backtrace.py
+++ b/tests/test_add_option_backtrace.py
@@ -8,7 +8,7 @@ def test_backtrace(writer):
     logger.add(writer, format="{message}", backtrace=True)
     try:
         1 / 0
-    except:
+    except Exception:
         logger.exception("")
     result_with = writer.read().strip()
 
@@ -18,7 +18,7 @@ def test_backtrace(writer):
     logger.add(writer, format="{message}", backtrace=False)
     try:
         1 / 0
-    except:
+    except Exception:
         logger.exception("")
     result_without = writer.read().strip()
 

--- a/tests/test_add_option_catch.py
+++ b/tests/test_add_option_catch.py
@@ -1,7 +1,6 @@
 import sys
 import pytest
 from loguru import logger
-import loguru
 import re
 import time
 

--- a/tests/test_add_option_diagnose.py
+++ b/tests/test_add_option_diagnose.py
@@ -7,7 +7,7 @@ def test_diagnose(writer):
     logger.add(writer, format="{message}", diagnose=True)
     try:
         1 / 0
-    except:
+    except Exception:
         logger.exception("")
     result_with = writer.read().strip()
 
@@ -17,7 +17,7 @@ def test_diagnose(writer):
     logger.add(writer, format="{message}", diagnose=False)
     try:
         1 / 0
-    except:
+    except Exception:
         logger.exception("")
     result_without = writer.read().strip()
 

--- a/tests/test_add_option_enqueue.py
+++ b/tests/test_add_option_enqueue.py
@@ -131,7 +131,6 @@ def test_not_caught_exception_queue_put(writer, capsys):
     logger.remove()
 
     out, err = capsys.readouterr()
-    lines = err.strip().splitlines()
     assert writer.read() == "It's fine\n"
     assert out == ""
     assert err == ""

--- a/tests/test_add_sinks.py
+++ b/tests/test_add_sinks.py
@@ -74,7 +74,10 @@ def test_file_sink_folder_creation(rep, tmpdir):
 @repetitions
 def test_function_sink(rep):
     a = []
-    func = lambda log_message: a.append(log_message)
+
+    def func(log_message):
+        a.append(log_message)
+
     log(func, rep)
     assert a == [expected] * rep
 

--- a/tests/test_contextualize.py
+++ b/tests/test_contextualize.py
@@ -1,8 +1,6 @@
-import loguru
 from loguru import logger
 import threading
 import asyncio
-import importlib
 import sys
 import pytest
 

--- a/tests/test_coroutine_sink.py
+++ b/tests/test_coroutine_sink.py
@@ -3,9 +3,7 @@ import sys
 import pytest
 import logging
 import loguru
-import time
 import threading
-import os
 import re
 import multiprocessing
 from loguru import logger

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -13,14 +13,14 @@ def test_string(value, monkeypatch):
 def test_bool_positive(value, monkeypatch):
     key = "VALID_BOOL_POS"
     monkeypatch.setenv(key, value)
-    assert env(key, bool) == True
+    assert env(key, bool) is True
 
 
 @pytest.mark.parametrize("value", ["NO", "0", "false"])
 def test_bool_negative(value, monkeypatch):
     key = "VALID_BOOL_NEG"
     monkeypatch.setenv(key, value)
-    assert env(key, bool) == False
+    assert env(key, bool) is False
 
 
 def test_int(monkeypatch):

--- a/tests/test_filesink_compression.py
+++ b/tests/test_filesink_compression.py
@@ -79,7 +79,6 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
     j = logger.add(str(tmpdir.join("test.log")), compression="tar.gz")
     logger.debug("test")
 
-    filesink = next(iter(logger._core.handlers.values()))._sink
     monkeypatch.setattr(loguru._file_sink, "get_ctime", creation_time)
 
     logger.remove(j)

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -7,9 +7,7 @@ import sys
 import time
 import tempfile
 import pathlib
-import platform
 import builtins
-from collections import namedtuple
 from unittest.mock import MagicMock, PropertyMock
 import loguru
 from loguru import logger
@@ -128,7 +126,7 @@ def linux_xattr_attributeerror_filesystem(monkeypatch, monkeypatch_filesystem):
 
 
 def test_renaming(tmpdir):
-    i = logger.add(str(tmpdir.join("file.log")), rotation=0, format="{message}")
+    logger.add(str(tmpdir.join("file.log")), rotation=0, format="{message}")
 
     time.sleep(0.1)
     logger.debug("a")
@@ -154,7 +152,7 @@ def test_renaming(tmpdir):
 
 def test_no_renaming(monkeypatch_date, tmpdir):
     monkeypatch_date(2018, 1, 1, 0, 0, 0, 0)
-    i = logger.add(str(tmpdir.join("file_{time}.log")), rotation=0, format="{message}")
+    logger.add(str(tmpdir.join("file_{time}.log")), rotation=0, format="{message}")
 
     monkeypatch_date(2019, 1, 1, 0, 0, 0, 0)
     logger.debug("a")
@@ -196,7 +194,9 @@ def test_size_rotation(monkeypatch_date, tmpdir, size):
 @pytest.mark.parametrize(
     "when, hours",
     [
-        # hours = [Should not trigger, should trigger, should not trigger, should trigger, should trigger]
+        # hours = [
+        #   Should not trigger, should trigger, should not trigger, should trigger, should trigger
+        # ]
         ("13", [0, 1, 20, 4, 24]),
         ("13:00", [0.2, 0.9, 23, 1, 48]),
         ("13:00:00", [0.5, 1.5, 10, 15, 72]),
@@ -383,7 +383,7 @@ def test_time_rotation_windows_no_setctime(
     reload_filesink_ctime_functions(monkeypatch)
 
     monkeypatch_date(2018, 10, 27, 5, 0, 0, 0)
-    i = logger.add(str(tmpdir.join("test.{time}.log")), format="{message}", rotation="2 h")
+    logger.add(str(tmpdir.join("test.{time}.log")), format="{message}", rotation="2 h")
     logger.info("1")
     monkeypatch_date(2018, 10, 27, 6, 30, 0, 0)
     logger.info("2")
@@ -414,7 +414,7 @@ def test_time_rotation_windows_setctime_exception(
     reload_filesink_ctime_functions(monkeypatch)
 
     monkeypatch_date(2018, 10, 27, 5, 0, 0, 0)
-    i = logger.add(str(tmpdir.join("test.{time}.log")), format="{message}", rotation="2 h")
+    logger.add(str(tmpdir.join("test.{time}.log")), format="{message}", rotation="2 h")
     logger.info("1")
     monkeypatch_date(2018, 10, 27, 6, 30, 0, 0)
     logger.info("2")
@@ -430,7 +430,7 @@ def test_time_rotation_windows_setctime_exception(
 def test_function_rotation(monkeypatch_date, tmpdir):
     monkeypatch_date(2018, 1, 1, 0, 0, 0, 0)
     x = iter([False, True, False])
-    i = logger.add(
+    logger.add(
         str(tmpdir.join("test_{time}.log")), rotation=lambda *_: next(x), format="{message}"
     )
     logger.debug("a")
@@ -477,10 +477,9 @@ def test_rename_existing_with_creation_time(monkeypatch, tmpdir):
         assert os.path.basename(filepath) == "test.log"
         return datetime.datetime(2018, 1, 1, 0, 0, 0, 0).timestamp()
 
-    i = logger.add(str(tmpdir.join("test.log")), rotation=10, format="{message}")
+    logger.add(str(tmpdir.join("test.log")), rotation=10, format="{message}")
     logger.debug("X")
 
-    filesink = next(iter(logger._core.handlers.values()))._sink
     monkeypatch.setattr(loguru._file_sink, "get_ctime", creation_time)
 
     logger.debug("Y" * 20)

--- a/tests/test_get_frame.py
+++ b/tests/test_get_frame.py
@@ -4,10 +4,11 @@ import loguru
 
 
 def test_with_sys_getframe(monkeypatch):
-    patched = lambda: None
-    monkeypatch.setattr(sys, "_getframe", patched)
+    def patched():
+        return
+    monkeypatch.setattr(sys, "_getframe", patched())
     get_frame_module = importlib.reload(loguru._get_frame)
-    assert get_frame_module.get_frame == patched
+    assert get_frame_module.get_frame == patched()
 
 
 def test_without_sys_getframe(monkeypatch):

--- a/tests/test_interception.py
+++ b/tests/test_interception.py
@@ -23,8 +23,15 @@ class InterceptHandler(logging.Handler):
 
 
 def test_formatting(writer):
-    fmt = "{name} - {file.name} - {function} - {level.name} - {level.no} - {line} - {module} - {message}"
-    expected = "tests.test_interception - test_interception.py - test_formatting - DEBUG - 10 - 31 - test_interception - This is the message\n"
+    fmt = (
+        "{name} - {file.name} - {function} - {level.name} - "
+        "{level.no} - {line} - {module} - {message}"
+    )
+
+    expected = (
+        "tests.test_interception - test_interception.py - test_formatting - DEBUG - "
+        "10 - 38 - test_interception - This is the message\n"
+    )
 
     with make_logging_logger("tests", InterceptHandler()) as logging_logger:
         logger.add(writer, format=fmt)
@@ -150,4 +157,4 @@ def test_using_logging_function(writer):
         logging.warning("ABC")
 
     result = writer.read()
-    assert result == "test_using_logging_function 150 test_interception test_interception.py ABC\n"
+    assert result == "test_using_logging_function 157 test_interception test_interception.py ABC\n"

--- a/tests/test_interception.py
+++ b/tests/test_interception.py
@@ -94,7 +94,7 @@ def test_exception(writer):
 
         try:
             1 / 0
-        except:
+        except Exception:
             logging_logger.exception("Oops...")
 
     lines = writer.read().strip().splitlines()

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -56,7 +56,7 @@ def test_exception_boolean(writer):
 
     try:
         1 / 0
-    except:
+    except Exception:
         logger.opt(exception=True).debug("Error {0} {record}", 1, record="test")
 
     lines = writer.read().strip().splitlines()
@@ -70,7 +70,7 @@ def test_exception_exc_info(writer):
 
     try:
         1 / 0
-    except:
+    except Exception:
         exc_info = sys.exc_info()
 
     logger.opt(exception=exc_info).debug("test")
@@ -86,7 +86,7 @@ def test_exception_class(writer):
 
     try:
         1 / 0
-    except:
+    except Exception:
         _, exc_class, _ = sys.exc_info()
 
     logger.opt(exception=exc_class).debug("test")
@@ -102,7 +102,7 @@ def test_exception_log_funcion(writer):
 
     try:
         1 / 0
-    except:
+    except Exception:
         logger.opt(exception=True).log(50, "Error")
 
     lines = writer.read().strip().splitlines()
@@ -128,13 +128,13 @@ def test_lazy(writer):
 
     logger.opt(lazy=True).log(20, "3: {}", laziness)
 
-    a = logger.add(writer, level=15, format="{level.no} => {message}")
-    b = logger.add(writer, level=20, format="{level.no} => {message}")
+    i = logger.add(writer, level=15, format="{level.no} => {message}")
+    logger.add(writer, level=20, format="{level.no} => {message}")
 
     logger.log(17, "4: {}", counter)
     logger.opt(lazy=True).log(14, "5: {lazy}", lazy=lambda: counter)
 
-    logger.remove(a)
+    logger.remove(i)
 
     logger.opt(lazy=True).log(16, "6: {0}", lambda: counter)
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,4 +1,3 @@
-import pytest
 from loguru import logger
 
 

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -1,7 +1,6 @@
 import logging
 import pickle
 import asyncio
-import sys
 import datetime
 
 import pytest
@@ -140,7 +139,7 @@ def test_pickling_standard_handler_root_logger_not_picklable(monkeypatch, capsys
     logger.add(handler, format="=> {message}", catch=False)
 
     pickled = pickle.dumps(logger)
-    unpickled = pickle.loads(pickled)
+    pickle.loads(pickled)
 
     logger.info("Ok")
     out, err = capsys.readouterr()

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -12,8 +12,15 @@ class PropagateHandler(logging.Handler):
 
 
 def test_formatting(capsys):
-    fmt = "%(name)s - %(filename)s - %(funcName)s - %(levelname)s - %(levelno)s - %(lineno)d - %(module)s - %(message)s"
-    expected = "tests.test_propagation - test_propagation.py - test_formatting - DEBUG - 10 - 20 - test_propagation - This is my message\n"
+    fmt = (
+        "%(name)s - %(filename)s - %(funcName)s - %(levelname)s - "
+        "%(levelno)s - %(lineno)d - %(module)s - %(message)s"
+    )
+
+    expected = (
+        "tests.test_propagation - test_propagation.py - test_formatting - DEBUG - "
+        "10 - 27 - test_propagation - This is my message\n"
+    )
 
     with make_logging_logger("tests.test_propagation", StreamHandler(sys.stderr), fmt):
         logger.add(PropagateHandler(), format="{message}")

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -76,7 +76,7 @@ def test_exception(capsys, use_opt):
 
         try:
             1 / 0
-        except:
+        except Exception:
             if use_opt:
                 logger.opt(exception=True).error("Oops...")
             else:

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,7 +1,6 @@
 import sys
 import pytest
 from loguru import logger
-import textwrap
 import time
 
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -179,7 +179,10 @@ def test_standard_handler():
 def test_multiple_handlers():
     logger.add(sys.__stdout__)
     logger.add(sys.__stderr__)
-    r = "<loguru.logger handlers=[(id=0, level=10, sink=<stdout>), (id=1, level=10, sink=<stderr>)]>"
+    r = "<loguru.logger handlers=[" \
+        "(id=0, level=10, sink=<stdout>), " \
+        "(id=1, level=10, sink=<stderr>)" \
+        "]>"
     assert repr(logger) == r
 
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -179,10 +179,12 @@ def test_standard_handler():
 def test_multiple_handlers():
     logger.add(sys.__stdout__)
     logger.add(sys.__stderr__)
-    r = "<loguru.logger handlers=[" \
-        "(id=0, level=10, sink=<stdout>), " \
-        "(id=1, level=10, sink=<stderr>)" \
+    r = (
+        "<loguru.logger handlers=["
+        "(id=0, level=10, sink=<stdout>), "
+        "(id=1, level=10, sink=<stderr>)"
         "]>"
+    )
     assert repr(logger) == r
 
 

--- a/tests/test_standard_handler.py
+++ b/tests/test_standard_handler.py
@@ -2,7 +2,6 @@ import pytest
 from loguru import logger
 import sys
 
-import logging
 from logging import StreamHandler, FileHandler, NullHandler, Handler
 from logging import Formatter
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -113,8 +113,8 @@ def test_safe_removing_while_logging(capsys):
 def test_safe_writing_after_removing(capsys):
     barrier = Barrier(2)
 
+    logger.add(NonSafeSink(1), format="{message}", catch=False)
     i = logger.add(NonSafeSink(1), format="{message}", catch=False)
-    j = logger.add(NonSafeSink(1), format="{message}", catch=False)
 
     def write():
         barrier.wait()
@@ -123,7 +123,7 @@ def test_safe_writing_after_removing(capsys):
     def remove():
         barrier.wait()
         time.sleep(0.5)
-        logger.remove(j)
+        logger.remove(i)
 
     threads = [Thread(target=write), Thread(target=remove)]
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py{35,36,37,38,py3}
 setenv = PYTHONPATH = {toxinidir}
 extras = dev
 commands =
-    flake8 --exit-zero loguru
+    flake8 --exit-zero loguru tests docs setup.py
     pytest --cov loguru/
     coverage report -m
 
@@ -24,6 +24,8 @@ max_doc_length = 100
 ignore =
     * W503  # Line break before binary operator (PEP8 now recommend to break after binary operator)
     * E203  # Whitespace before ":" in slices
+exclude =
+    tests/exceptions/source
 
 [coverage:html]
 title = Loguru Coverage


### PR DESCRIPTION
As proposed in #353, this PR consist of:

**Fixed _flake8_ errors in tests/, docs/ and setup.py. For example:**
- Unused imports;
- Unused variables and lines of code in tests;
- [Usage of lambda in tests instead of function](https://www.flake8rules.com/rules/E731.html);
- Line length exceeding limit in tests;
- [Usage of bare except](https://www.flake8rules.com/rules/E722.html);
- [Inappropriate comparison of boolean types in tests](https://www.flake8rules.com/rules/E712.html).

**Optimized __Logger_ initialization reading using key/value.** I think, such style will give developers better visual understanding.

Also, **updated the CHANGELOG.rst** as mentioned in [documentation](https://loguru.readthedocs.io/en/stable/project/contributing.html#implementing-changes).