### PR TITLE
Added custom serialize methods

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -163,7 +163,12 @@ class Handler:
                     formatted = precomputed_format.format_map(formatter_record)
 
             if self._serialize:
-                formatted = self._serialize_record(formatted, record)
+                if hasattr(self._serialize, "__call__"):
+                    serializer = self._serialize
+                else:
+                    serializer = json.dumps
+
+                formatted = self._serialize_record(serializer, formatted, record)
 
             str_record = Message(formatted)
             str_record.record = record
@@ -219,7 +224,7 @@ class Handler:
         return self._levelno
 
     @staticmethod
-    def _serialize_record(text, record):
+    def _serialize_record(serializer, text, record):
         exception = record["exception"]
 
         if exception is not None:
@@ -255,7 +260,7 @@ class Handler:
             },
         }
 
-        return json.dumps(serializable, default=str) + "\n"
+        return serializer(serializable, default=str) + "\n"
 
     def _queued_writer(self):
         message = None

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -255,9 +255,11 @@ class Logger:
             Whether the color markups contained in the formatted message should be converted to ansi
             codes for terminal coloration, or stripped otherwise. If ``None``, the choice is
             automatically made based on the sink being a tty or not.
-        serialize : |bool|, optional
+        serialize : |bool| or |function|, optional
             Whether the logged message and its records should be first converted to a JSON string
             before being sent to the sink.
+            If serialize is a function, it will be used as serializer, and must
+            be compatible with json.dumps' interface.
         backtrace : |bool|, optional
             Whether the exception trace formatted should be extended upward, beyond the catching
             point, to show the full stacktrace which generated the error.


### PR DESCRIPTION
Whenever you specify a callable as "serialize" option to logger, it will
use it as serializer instead of json.dumps().

This can be used to add more "extreme" custom formats such as SPLUNK's.
A simple CSV logger has been added as test.

Relates to #372