### PR TITLE
Add logger.catch(default=...) to type hints

### DIFF
--- a/loguru/__init__.pyi
+++ b/loguru/__init__.pyi
@@ -289,6 +289,7 @@ class Logger:
         reraise: bool = ...,
         onerror: Optional[Callable[[BaseException], None]] = ...,
         exclude: Optional[Union[Type[BaseException], Tuple[Type[BaseException], ...]]] = ...,
+        default: Any = ...,
         message: str = ...
     ) -> Catcher: ...
     @overload


### PR DESCRIPTION
Hi there, my IDE shows errors when using the `default` param of `logger.catch`:

![grafik](https://user-images.githubusercontent.com/88278/109191788-c93dc380-7796-11eb-84fc-98a9e930ea67.png)

This PR fixes it. Haven't worked with pyi files before, so hope this is the correct way to specify it.
Please shout out if this requires tests of any kind.