### PR TITLE
Feature/onerror with self

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1213,7 +1213,7 @@ class Logger:
                 # basically just runs over members of arg_0 and sees if the decorated method is one in one of the tuples
                 # tuple -> (name, val)
                 if args:
-                    if list(filter(lambda attr_tup: True if attr_tup[0] == decorated.__name__ else False, getmembers(args[0])):
+                    if list(filter(lambda attr_tup: True if attr_tup[0] == decorated.__name__ else False, getmembers(args[0]))):
                         self_._decorated_method_bound = args[0]
 
             def __call__(_, function):

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1169,7 +1169,7 @@ class Logger:
         class Catcher:
             def __init__(self_, from_decorator):
                 self_._from_decorator = from_decorator
-                self_._decorating_method = False
+                self_._decorated_method_Self = None
 
             def __enter__(self_):
                 return None
@@ -1199,7 +1199,7 @@ class Logger:
 
                 return not reraise
 
-            def __check_method_or_func(self, args, decorated):
+            def __method_or_func(self, args, decorated):
                 # return True if the method decorated is a method of cls and false if it does not receive it
                 # class/instance methods -> return True
                 # regular function and static -> return False
@@ -1207,9 +1207,9 @@ class Logger:
                 # basically just runs over members of arg_0 and sees if the decorated method is one in one of the tuples
                 # tuple -> (name, val)
                 if args:
-                    return True if list(filter(lambda attr_tup: True if attr_tup[0] == decorated.__name__ else False,
-                                               getmembers(args[0]))) else False
-                return False
+                    return args[0] if list(filter(lambda attr_tup: True if attr_tup[0] == decorated.__name__ else False,
+                                               getmembers(args[0]))) else None
+                return None
 
             def __call__(_, function):
                 catcher = Catcher(True)

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1205,7 +1205,7 @@ class Logger:
 
                 return not reraise
 
-            def __method_or_func(self, args, decorated):
+            def __set_decorated_bound(self_, args, decorated):
                 # return True if the method decorated is a method of cls and false if it does not receive it
                 # class/instance methods -> return True
                 # regular function and static -> return False
@@ -1213,9 +1213,8 @@ class Logger:
                 # basically just runs over members of arg_0 and sees if the decorated method is one in one of the tuples
                 # tuple -> (name, val)
                 if args:
-                    return args[0] if list(filter(lambda attr_tup: True if attr_tup[0] == decorated.__name__ else False,
-                                               getmembers(args[0]))) else None
-                return None
+                    if list(filter(lambda attr_tup: True if attr_tup[0] == decorated.__name__ else False, getmembers(args[0])):
+                        self_._decorated_method_bound = args[0]
 
             def __call__(_, function):
                 catcher = Catcher(True)

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -82,7 +82,7 @@ import re
 import sys
 import warnings
 from collections import namedtuple
-from inspect import isclass, iscoroutinefunction, isgeneratorfunction, getmembers
+from inspect import isclass, iscoroutinefunction, isgeneratorfunction, getmembers, signature
 from multiprocessing import current_process
 from os.path import basename, splitext
 from threading import current_thread
@@ -1169,7 +1169,7 @@ class Logger:
         class Catcher:
             def __init__(self_, from_decorator):
                 self_._from_decorator = from_decorator
-                self_._decorated_method_Self = None
+                self_._decorated_method_bound = None
 
             def __enter__(self_):
                 return None
@@ -1195,7 +1195,13 @@ class Logger:
                 self._log(level_id, static_level_no, from_decorator, catch_options, message, (), {})
 
                 if onerror is not None:
-                    onerror(value)
+                    if self_._decorated_method_bound:
+                        if 'obj_bound' in signature(onerror).parameters.keys():
+                            onerror(value, obj_bound=self_._decorated_method_bound)
+                        else:
+                            onerror(value)
+                    else:
+                        onerror(value)
 
                 return not reraise
 

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1169,6 +1169,7 @@ class Logger:
         class Catcher:
             def __init__(self_, from_decorator):
                 self_._from_decorator = from_decorator
+                self_._decorating_method = False
 
             def __enter__(self_):
                 return None

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1222,7 +1222,7 @@ class Logger:
                 if iscoroutinefunction(function):
 
                     async def catch_wrapper(*args, **kwargs):
-
+                        catcher._set_decorated_bound(args, function)
                         with catcher:
                             return await function(*args, **kwargs)
                         return default
@@ -1230,6 +1230,7 @@ class Logger:
                 elif isgeneratorfunction(function):
 
                     def catch_wrapper(*args, **kwargs):
+                        catcher._set_decorated_bound(args, function)
                         with catcher:
                             return (yield from function(*args, **kwargs))
                         return default
@@ -1237,6 +1238,7 @@ class Logger:
                 else:
 
                     def catch_wrapper(*args, **kwargs):
+                        catcher._set_decorated_bound(args, function)
                         with catcher:
                             return function(*args, **kwargs)
                         return default

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1205,7 +1205,7 @@ class Logger:
 
                 return not reraise
 
-            def __set_decorated_bound(self_, args, decorated):
+            def _set_decorated_bound(self_, args, decorated):
                 # return True if the method decorated is a method of cls and false if it does not receive it
                 # class/instance methods -> return True
                 # regular function and static -> return False
@@ -1222,6 +1222,7 @@ class Logger:
                 if iscoroutinefunction(function):
 
                     async def catch_wrapper(*args, **kwargs):
+
                         with catcher:
                             return await function(*args, **kwargs)
                         return default

--- a/tests/test_exceptions_catch.py
+++ b/tests/test_exceptions_catch.py
@@ -514,3 +514,45 @@ def test_onerror_with_bound():
     assert TestCls.cls_var == 'working'
     TestCls.test3()
     assert TestCls.cls_var == 'from_func'
+
+def test_onerror_with_bound_reverse():
+
+    def self_test_onerror(exception):
+        TestCls.cls_var = 'working self without self'
+
+    def cls_test_onerror(exception):
+        TestCls.cls_var = 'working cls without cls'
+
+    def onerror_test_on_regular_func(exception, obj_bound):
+        # raise exception
+        # TestCls.cls_var = 'from_func'
+        pass
+
+    class TestCls:
+        cls_var = None
+
+        def __init__(self):
+            self.my_instance_var = None
+
+        @logger.catch(onerror=self_test_onerror)
+        def test1(self, a, b, c):
+            raise Exception('test')
+
+        @classmethod
+        @logger.catch(onerror=cls_test_onerror)
+        def test2(cls):
+            raise Exception('test')
+
+        @staticmethod
+        @logger.catch(onerror=onerror_test_on_regular_func)
+        def test3():
+            raise Exception('from func')
+
+    t = TestCls()
+    t.test1(1,2,3)
+    assert TestCls.cls_var == 'working self without self'
+    TestCls.test2()
+    assert TestCls.cls_var == 'working cls without cls'
+    with pytest.raises(TypeError):
+        TestCls.test3()
+


### PR DESCRIPTION
this allows the onerror method to receive the self, cls on methods that get them -> by using in the onerror methods the key word obj_bound -> but to not break earlier code I made it so that if the method does not have obj_bound in signature it won't pass the self/cls over. in regular and static methods it doesn't pass it ever and raises error if it is requested.