### PR TITLE
Docs for caplog integration that avoids deadlocks

### DIFF
--- a/docs/resources/migration.rst
+++ b/docs/resources/migration.rst
@@ -230,22 +230,16 @@ Making things work with Pytest and caplog
 
 If you've followed all the migration guidelines thus far, you'll notice that this test will fail. This is because |pytest|_ links to the standard library's ``logging`` module.
 
-So to fix things, we need to add a sink that propagates Loguru to ``logging``.
-This is done on the fixture itself by mokeypatching |caplog|_. In your ``conftest.py`` file, add the following::
+So to fix things, we need to add a sink that propagates Loguru to the caplog handler.
+This is done by overriding the |caplog|_ fixture to capture its handler. In your ``conftest.py`` file, add the following::
 
-    import logging
     import pytest
-    from _pytest.logging import caplog as _caplog
     from loguru import logger
 
     @pytest.fixture
     def caplog(_caplog):
-        class PropogateHandler(logging.Handler):
-            def emit(self, record):
-                logging.getLogger(record.name).handle(record)
-
-        handler_id = logger.add(PropogateHandler(), format="{message} {extra}", level="TRACE")
+        handler_id = logger.add(_caplog.handler, format="{message}")
         yield _caplog
         logger.remove(handler_id)
 
-Run your tests and things should all be working as expected. Additional information can be found in `GH#59`_.
+Run your tests and things should all be working as expected. Additional information can be found in `GH#59`_ and `GH#474`_.

--- a/docs/resources/migration.rst
+++ b/docs/resources/migration.rst
@@ -43,6 +43,7 @@ Switching from standard ``logging`` to ``loguru``
 .. _caplog: https://docs.pytest.org/en/latest/logging.html?highlight=caplog#caplog-fixture
 
 .. _`GH#59`: https://github.com/Delgan/loguru/issues/59
+.. _`GH#474`: https://github.com/Delgan/loguru/issues/474
 
 
 
@@ -235,11 +236,12 @@ This is done by overriding the |caplog|_ fixture to capture its handler. In your
 
     import pytest
     from loguru import logger
+    from _pytest.logging import LogCaptureFixture
 
     @pytest.fixture
-    def caplog(_caplog):
-        handler_id = logger.add(_caplog.handler, format="{message}")
-        yield _caplog
+    def caplog(caplog: LogCaptureFixture):
+        handler_id = logger.add(caplog.handler, format="{message}")
+        yield caplog
         logger.remove(handler_id)
 
 Run your tests and things should all be working as expected. Additional information can be found in `GH#59`_ and `GH#474`_.


### PR DESCRIPTION
The previous suggestion resulted in a deadlock when an InterceptHandler was used to integrate standard logging into loguru. Fixes #474.