### PR TITLE
When serializing, preserve Unicode information

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 
 - Modify coroutine sink to make it discard log messages when ``loop=None`` and no event loop is running (due to internally using ``asyncio.get_running_loop()`` in place of ``asyncio.get_event_loop()``).
 - Remove the possibility to add a coroutine sink with ``enqueue=True`` if ``loop=None`` and no event loop is running.
+- Prevent non-ascii characters to be escaped while logging JSON message with ``serialize=True`` (`#574 <https://github.com/Delgan/loguru/pull/575>`_, thanks `@ponponon <https://github.com/ponponon>`_).
 - Fix ``flake8`` errors and improve code readability (`#353 <https://github.com/Delgan/loguru/issues/353>`_, thanks `@AndrewYakimets <https://github.com/AndrewYakimets>`_).
 
 

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -257,7 +257,7 @@ class Handler:
             },
         }
 
-        return json.dumps(serializable, default=str) + "\n"
+        return json.dumps(serializable, default=str, ensure_ascii=False) + "\n"
 
     def _queued_writer(self):
         message = None


### PR DESCRIPTION

Hi, I'm here again, I resubmitted the pull request.

---------------

👇 Here is the original content：

I want to keep the original information of the Unicode code and not serialize it to ASCII

```python
In [2]: json.dumps({"中文":"你好"})
Out[2]: '{"\\u4e2d\\u6587": "\\u4f60\\u597d"}'

In [3]: json.dumps({"中文":"你好"},ensure_ascii=False)
Out[3]: '{"中文": "你好"}'
```