### PR TITLE
Fix log injection

### DIFF
--- a/docs/resources/recipes.rst
+++ b/docs/resources/recipes.rst
@@ -93,7 +93,7 @@ You should also avoid logging a message that could be maliciously hand-crafted b
     logger.info(message, value=SomeValue(10))
 
 
-Another danger due to external input is the possibility of a log injection attack. Consider that you may need to escape user values before logging them: `Is your Python code vulnerable to log injection? <https://dev.arie.bovenberg.net/blog/is-your-python-code-vulnerable-to-log-injection/>`_
+Another danger due to external input is the possibility of a log injection attack. This can happen with the option `raw=True`. Consider that you may need to escape user values before logging them: `Is your Python code vulnerable to log injection? <https://dev.arie.bovenberg.net/blog/is-your-python-code-vulnerable-to-log-injection/>`_
 
 .. code::
 
@@ -101,7 +101,7 @@ Another danger due to external input is the possibility of a log injection attac
 
     # If value is "Josh logged in.\nINFO User James" then there will appear to be two log entries.
     username = external_data()
-    logger.info("User " + username + " logged in.")
+    logger.opt(raw=True).info("User " + username + " logged in.")
 
 
 Note that by default, Loguru will display the value of existing variables when an ``Exception`` is logged. This is very useful for debugging but could lead to credentials appearing in log files. Make sure to turn it off in production (or set the ``LOGURU_DIAGNOSE=NO`` environment variable).

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1287,7 +1287,8 @@ class Logger:
             contains.
         raw : |bool|, optional
             If ``True``, the formatting of each sink will be bypassed and the message will be sent
-            as is.
+            as is. Note that this opens up the vulnerability CWE-93: Improper Neutralization of CRLF
+            Sequences ('CRLF Injection')
         capture : |bool|, optional
             If ``False``, the ``**kwargs`` of logged message will not automatically populate
             the ``extra`` dict (although they are still used for formatting).
@@ -1935,6 +1936,15 @@ class Logger:
             exception = RecordException(type_, value, traceback)
         else:
             exception = None
+
+        clrf_save = not raw
+
+        if clrf_save:
+            try:
+                message = message.replace("\n", "\\n").replace("\r", "\\r")
+            except (AttributeError, TypeError):
+                # AttributeError if message is not a string, TypeError if it's a binary string
+                pass
 
         log_record = {
             "elapsed": elapsed,

--- a/tests/test_clrf_save.py
+++ b/tests/test_clrf_save.py
@@ -3,13 +3,16 @@ import pytest
 from loguru import logger
 
 
-@pytest.mark.parametrize("raw,original,replacement", (
-    (False, "\n", "\\n"),
-    (False, "\r", "\\r"),
-    (True, "\n", "\n"),
-    (True, "\r", "\r"),
-))
+@pytest.mark.parametrize(
+    "raw,original,replacement",
+    (
+        (False, "\n", "\\n"),
+        (False, "\r", "\\r"),
+        (True, "\n", "\n"),
+        (True, "\r", "\r"),
+    ),
+)
 def test_clrf(writer, raw, original, replacement):
     logger.add(writer, format="{message}")
-    logger.opt(raw=raw).debug(f"Line{original}Next line")
-    assert writer.read() == f"Line{replacement}Next line" + ("\n" if not raw else "")
+    logger.opt(raw=raw).debug("Line" + original + "Next line")
+    assert writer.read() == "Line" + replacement + "Next line" + ("\n" if not raw else "")

--- a/tests/test_clrf_save.py
+++ b/tests/test_clrf_save.py
@@ -1,0 +1,15 @@
+import pytest
+
+from loguru import logger
+
+
+@pytest.mark.parametrize("raw,original,replacement", (
+    (False, "\n", "\\n"),
+    (False, "\r", "\\r"),
+    (True, "\n", "\n"),
+    (True, "\r", "\r"),
+))
+def test_clrf(writer, raw, original, replacement):
+    logger.add(writer, format="{message}")
+    logger.opt(raw=raw).debug(f"Line{original}Next line")
+    assert writer.read() == f"Line{replacement}Next line" + ("\n" if not raw else "")


### PR DESCRIPTION
This PR fixes the log injection issue as described [here](https://www.huntr.dev/bounties/73ebb08a-0415-41be-b9b0-0cea067f6771/). The issue got attention in [bc1dab](https://www.github.com/delgan/loguru/commit/bc1dab4cc5044d704a980f5675b9d02f9f61b528), but was never fixed, so our repository manager was [still complaining](https://ossindex.sonatype.org/vulnerability/sonatype-2022-0703?component-type=pypi&component-name=loguru):

![image](https://user-images.githubusercontent.com/49157844/190192490-d80c7aa8-f371-4361-ba0a-048888eb275e.png)

Happy to hear your thoughts.