### PR TITLE
Avoid deadlock caused by generational GC and object finalizers

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -104,9 +104,9 @@ class Handler:
         if getattr(self._lock_acquired, "acquired", False):
             raise RuntimeError(
                 "Could not acquire internal lock because it was already in use (deadlock avoided). "
-                "This likely happened because the logger was re-used inside a sink, a signal handler "
-                "or a '__del__' method. This is not permitted because the logger and its handlers are "
-                "not re-entrant."
+                "This likely happened because the logger was re-used inside a sink, a signal "
+                "handler or a '__del__' method. This is not permitted because the logger and its "
+                "handlers are not re-entrant."
             )
         self._lock_acquired.acquired = True
         try:

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -317,6 +317,7 @@ class Handler:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None
+        state["_lock_acquired"] = None
         state["_memoize_dynamic_format"] = None
         if self._enqueue:
             state["_sink"] = None
@@ -327,6 +328,7 @@ class Handler:
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._lock = create_handler_lock()
+        self._lock_acquired = threading.local()
         if self._is_formatter_dynamic:
             if self._colorize:
                 self._memoize_dynamic_format = memoize(prepare_colored_format)

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -5,7 +5,7 @@ import os
 from threading import Thread
 
 from ._colorizer import Colorizer
-from ._locks_machinery import create_handler_lock
+from ._locks_machinery import HandlerLockNotReentrant, create_handler_lock
 
 
 def prepare_colored_format(format_, ansi_level):
@@ -175,7 +175,8 @@ class Handler:
                     self._queue.put(str_record)
                 else:
                     self._sink.write(str_record)
-
+        except HandlerLockNotReentrant:
+            self._error_interceptor.print(record)
         except Exception:
             if not self._error_interceptor.should_catch():
                 raise

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -2,10 +2,12 @@ import functools
 import json
 import multiprocessing
 import os
+import threading
+from contextlib import contextmanager
 from threading import Thread
 
 from ._colorizer import Colorizer
-from ._locks_machinery import HandlerLockNotReentrant, create_handler_lock
+from ._locks_machinery import create_handler_lock
 
 
 def prepare_colored_format(format_, ansi_level):
@@ -64,6 +66,7 @@ class Handler:
 
         self._stopped = False
         self._lock = create_handler_lock()
+        self._lock_acquired = threading.local()
         self._queue = None
         self._confirmation_event = None
         self._confirmation_lock = None
@@ -94,6 +97,24 @@ class Handler:
 
     def __repr__(self):
         return "(id=%d, level=%d, sink=%s)" % (self._id, self._levelno, self._name)
+
+    @contextmanager
+    def _protected_lock(self):
+        """Acquire the lock, but fail fast if its already acquired by the current thread."""
+        if getattr(self._lock_acquired, "acquired", False):
+            raise RuntimeError(
+                "Could not acquire internal lock because it was already in use (deadlock avoided). "
+                "This likely happened because the logger was re-used inside a sink, a signal handler "
+                "or a '__del__' method. This is not permitted because the logger and its handlers are "
+                "not re-entrant."
+            )
+        self._lock_acquired.acquired = True
+        try:
+            self._lock.acquire()
+            yield
+        finally:
+            self._lock.release()
+            self._lock_acquired.acquired = False
 
     def emit(self, record, level_id, from_decorator, is_raw, colored_message):
         try:
@@ -168,22 +189,20 @@ class Handler:
             str_record = Message(formatted)
             str_record.record = record
 
-            with self._lock:
+            with self._protected_lock():
                 if self._stopped:
                     return
                 if self._enqueue:
                     self._queue.put(str_record)
                 else:
                     self._sink.write(str_record)
-        except HandlerLockNotReentrant:
-            self._error_interceptor.print(record)
         except Exception:
             if not self._error_interceptor.should_catch():
                 raise
             self._error_interceptor.print(record)
 
     def stop(self):
-        with self._lock:
+        with self._protected_lock():
             self._stopped = True
             if self._enqueue:
                 if self._owner_process_pid != os.getpid():
@@ -208,7 +227,7 @@ class Handler:
         if self._enqueue and self._owner_process_pid != os.getpid():
             return
 
-        with self._lock:
+        with self._protected_lock():
             await self._sink.complete()
 
     def update_format(self, level_id):

--- a/loguru/_locks_machinery.py
+++ b/loguru/_locks_machinery.py
@@ -22,7 +22,8 @@ class _HandlerLockWrapper:
     def __enter__(self):
         if getattr(self._local, "acquired", False):
             raise HandlerLockNotReentrant(
-                "Tried to emit a log in the process of handling a log. Log handler is not re-entrant."
+                "Tried to emit a log in the process of handling a log. Log handler is not "
+                "re-entrant."
             )
         self._local.acquired = True
         self._lock.acquire()

--- a/loguru/_locks_machinery.py
+++ b/loguru/_locks_machinery.py
@@ -2,7 +2,6 @@ import os
 import threading
 import weakref
 
-
 if not hasattr(os, "register_at_fork"):
 
     def create_logger_lock():

--- a/loguru/_locks_machinery.py
+++ b/loguru/_locks_machinery.py
@@ -10,7 +10,8 @@ class HandlerLockNotReentrant(RuntimeError):
 class _HandlerLockWrapper:
     """Lock wrapper for the handler.
 
-    This avoids deadlock by propagating an exception rather than waiting forever.
+    This avoids thread-local deadlock by propagating an exception rather than waiting forever.
+    See: https://github.com/Delgan/loguru/issues/712
     """
 
     def __init__(self, lock):

--- a/loguru/_locks_machinery.py
+++ b/loguru/_locks_machinery.py
@@ -3,45 +3,13 @@ import threading
 import weakref
 
 
-class HandlerLockNotReentrant(RuntimeError):
-    pass
-
-
-class _HandlerLockWrapper:
-    """Lock wrapper for the handler.
-
-    This avoids thread-local deadlock by propagating an exception rather than waiting forever.
-    See: https://github.com/Delgan/loguru/issues/712
-    """
-
-    def __init__(self, lock):
-        self._lock = lock
-        self._local = threading.local()
-        self._local.acquired = False
-
-    def __enter__(self):
-        if getattr(self._local, "acquired", False):
-            raise HandlerLockNotReentrant(
-                "Tried to emit a log in the process of handling a log. Log handler is not "
-                "re-entrant."
-            )
-        self._local.acquired = True
-        self._lock.acquire()
-        return
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self._lock.release()
-        self._local.acquired = False
-        return
-
-
 if not hasattr(os, "register_at_fork"):
 
     def create_logger_lock():
         return threading.Lock()
 
     def create_handler_lock():
-        return _HandlerLockWrapper(threading.Lock())
+        return threading.Lock()
 
 else:
     # While forking, we need to sanitize all locks to make sure the child process doesn't run into
@@ -80,4 +48,4 @@ else:
     def create_handler_lock():
         lock = threading.Lock()
         handler_locks.add(lock)
-        return _HandlerLockWrapper(lock)
+        return lock

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,65 @@
+import gc
+
+import pytest
+
+from loguru import logger
+
+
+class CyclicReference:
+    """A minimal cyclic reference.
+
+    Cyclical references are garbage collected using the generational collector rather than
+    via reference counting. This is important here, because the generational collector runs
+    periodically, meaning that it is hard to predict when the stack will be overtaken by a
+    garbage collection process - but it will almost always be when allocating memory of some
+    kind.
+
+    When this object is garbage-collected, a log will be emitted.
+    """
+
+    def __init__(self, _other: "CyclicReference" = None):
+        self.other = _other or CyclicReference(_other=self)
+
+    def __del__(self):
+        logger.info("tearing down")
+
+
+@pytest.fixture()
+def _remove_cyclic_references():
+    """Prevent cyclic isolate finalizers bleeding into other tests."""
+    try:
+        yield
+    finally:
+        for generation in range(3):
+            gc.collect(generation=generation)
+
+
+def test_no_deadlock_on_generational_garbage_collection(_remove_cyclic_references):
+    """Regression test for https://github.com/Delgan/loguru/issues/712
+
+    Assert that deadlocks do not occur when a cyclic isolate containing log output in
+    finalizers is collected by generational GC, during the output of another log message.
+    """
+
+    # GIVEN a sink which assigns some memory
+    output = []
+
+    def sink(message):
+        # This simulates assigning some memory as part of log handling. Eventually this will
+        # trigger the generational garbage collector to take over here.
+        # You could replace it with `json.dumps(message.record)` to get the same effect.
+        _ = [dict() for _ in range(20)]
+
+        # Actually write the message somewhere
+        output.append(message)
+
+    logger.add(sink, colorize=False)
+
+    # WHEN there are cyclic isolates in memory which log on GC
+    # AND logs are produced long enough to trigger generational GC
+    for _ in range(1000):
+        CyclicReference()
+        logger.info("test")
+
+    # THEN deadlock should not be reached
+    assert True


### PR DESCRIPTION
This PR implements a solution to #712 as discussed [here](https://github.com/Delgan/loguru/issues/712#issuecomment-1263719117).

If a re-entrant logging call is performed (a particular thread emits a message whilst in the process of emitting another), then the log will not be emitted, and instead handled by the error interceptor. This differs from the current behaviour, which is that a deadlock would be reached.

Resolves #712 