### PR TITLE
Fix escaped characters representation in logs.

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -187,6 +187,8 @@ class Handler:
 
             str_record = Message(formatted)
             str_record.record = record
+            str_record = str_record.encode('ascii').decode('unicode-escape').encode('utf-16', 'surrogatepass').decode(
+                'utf-16')
 
             with self._protected_lock():
                 if self._stopped:


### PR DESCRIPTION
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/45798812/221512668-fb02b272-d438-4a27-afec-3fcab448ee74.png">
Hi! Log entries with non utf-8 characters are printed escaped. I do not see any way to make them be printed in original way. In this pull request is an example how to make logs correct. Not sure that this is a general solution, but maybe will be good starting point to look at.
