### PR TITLE
improve library disable readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -377,8 +377,6 @@ Using the logger in your scripts is easy, and you can |configure|_ it at start. 
 
     # For libraries, should be your library's `__name__`
     logger.disable("my_library")
-    # or
-    logger.disable(__name__)
 
     logger.info("No matter added sinks, this message is not displayed")
     logger.enable("my_library")

--- a/README.rst
+++ b/README.rst
@@ -375,7 +375,7 @@ Using the logger in your scripts is easy, and you can |configure|_ it at start. 
     }
     logger.configure(**config)
 
-    # For libraries
+    # For libraries, should be your library's `__name__`
     logger.disable("my_library")
     # or
     logger.disable(__name__)

--- a/README.rst
+++ b/README.rst
@@ -377,6 +377,9 @@ Using the logger in your scripts is easy, and you can |configure|_ it at start. 
 
     # For libraries
     logger.disable("my_library")
+    # or
+    logger.disable(__name__)
+
     logger.info("No matter added sinks, this message is not displayed")
     logger.enable("my_library")
     logger.info("This message however is propagated to the sinks")

--- a/README.rst
+++ b/README.rst
@@ -377,8 +377,9 @@ Using the logger in your scripts is easy, and you can |configure|_ it at start. 
 
     # For libraries, should be your library's `__name__`
     logger.disable("my_library")
-
     logger.info("No matter added sinks, this message is not displayed")
+
+    # In your application, enable the logger in the library
     logger.enable("my_library")
     logger.info("This message however is propagated to the sinks")
 


### PR DESCRIPTION
Original example is a little bit confusing, is take me a while to figure out that I need to disable library's `__name__` instead of name I used in `logger.bind(name='my_library')`