### PR TITLE
_recattrs.py: take into account exception coming from other classes

### DIFF
--- a/loguru/_recattrs.py
+++ b/loguru/_recattrs.py
@@ -70,12 +70,10 @@ class RecordException(namedtuple("RecordException", ("type", "value", "traceback
         # dumped value during unpickling, but this requires using "pickle.loads()" which is
         # flagged as insecure by some security tools.
         # __reduce__ function does not alway raise PickleError. Multidict, for example, raise
-        # TypeError. In those cases, we need to catch TypeError exception.
+        # TypeError. To manage all the cases, we catch Exception.
         try:
             pickle.dumps(self.value)
-        except pickle.PickleError:
-            return (RecordException, (self.type, None, None))
-        except TypeError:
+        except Exception:
             return (RecordException, (self.type, None, None))
         else:
             return (RecordException, (self.type, self.value, None))

--- a/loguru/_recattrs.py
+++ b/loguru/_recattrs.py
@@ -71,7 +71,7 @@ class RecordException(namedtuple("RecordException", ("type", "value", "traceback
         # flagged as insecure by some security tools.
         try:
             pickle.dumps(self.value)
-        except pickle.PickleError:
+        except (pickle.PickleError, TypeError) as err:
             return (RecordException, (self.type, None, None))
         else:
             return (RecordException, (self.type, self.value, None))

--- a/loguru/_recattrs.py
+++ b/loguru/_recattrs.py
@@ -69,9 +69,13 @@ class RecordException(namedtuple("RecordException", ("type", "value", "traceback
         # we remove the value in case or error. As an optimization, we could have re-used the
         # dumped value during unpickling, but this requires using "pickle.loads()" which is
         # flagged as insecure by some security tools.
+        # __reduce__ function does not alway raise PickleError. Multidict, for example, raise
+        # TypeError. In those cases, we need to catch TypeError exception.
         try:
             pickle.dumps(self.value)
-        except (pickle.PickleError, TypeError) as err:
+        except pickle.PickleError:
+            return (RecordException, (self.type, None, None))
+        except TypeError:
             return (RecordException, (self.type, None, None))
         else:
             return (RecordException, (self.type, self.value, None))

--- a/tests/test_add_option_enqueue.py
+++ b/tests/test_add_option_enqueue.py
@@ -18,6 +18,14 @@ class NotPicklable:
         pass
 
 
+class NotPicklableTypeError:
+    def __getstate__(self):
+        raise TypeError("You shall not serialize me!")
+
+    def __setstate__(self, state):
+        pass
+
+
 class NotUnpicklable:
     def __getstate__(self):
         return "..."
@@ -89,6 +97,24 @@ def test_caught_exception_queue_put(writer, capsys):
     assert lines[-1] == "--- End of logging error ---"
 
 
+def test_caught_exception_queue_put_typerror(writer, capsys):
+    logger.add(writer, enqueue=True, catch=True, format="{message}")
+
+    logger.info("It's fine")
+    logger.bind(broken=NotPicklableTypeError()).info("Bye bye...")
+    logger.info("It's fine again")
+    logger.remove()
+
+    out, err = capsys.readouterr()
+    lines = err.strip().splitlines()
+    assert writer.read() == "It's fine\nIt's fine again\n"
+    assert out == ""
+    assert lines[0] == "--- Logging error in Loguru Handler #0 ---"
+    assert re.match(r"Record was: \{.*Bye bye.*\}", lines[1])
+    assert lines[-2].endswith("TypeError: You shall not serialize me!")
+    assert lines[-1] == "--- End of logging error ---"
+
+
 def test_caught_exception_queue_get(writer, capsys):
     logger.add(writer, enqueue=True, catch=True, format="{message}")
 
@@ -131,6 +157,22 @@ def test_not_caught_exception_queue_put(writer, capsys):
 
     with pytest.raises(pickle.PicklingError, match=r"You shall not serialize me!"):
         logger.bind(broken=NotPicklable()).info("Bye bye...")
+
+    logger.remove()
+
+    out, err = capsys.readouterr()
+    assert writer.read() == "It's fine\n"
+    assert out == ""
+    assert err == ""
+
+
+def test_not_caught_exception_queue_put_typeerror(writer, capsys):
+    logger.add(writer, enqueue=True, catch=False, format="{message}")
+
+    logger.info("It's fine")
+
+    with pytest.raises(TypeError, match=r"You shall not serialize me!"):
+        logger.bind(broken=NotPicklableTypeError()).info("Bye bye...")
 
     logger.remove()
 

--- a/tests/test_add_option_enqueue.py
+++ b/tests/test_add_option_enqueue.py
@@ -90,7 +90,7 @@ def test_caught_exception_queue_put(writer, capsys):
     assert out == ""
     assert lines[0] == "--- Logging error in Loguru Handler #0 ---"
     assert re.match(r"Record was: \{.*Bye bye.*\}", lines[1])
-    assert len(re.findall(r"You shall not serialize me!", err)) == 2
+    assert len(re.findall(r"You shall not serialize me!", err)) >= 2
     assert lines[-1] == "--- End of logging error ---"
 
 

--- a/tests/test_add_option_enqueue.py
+++ b/tests/test_add_option_enqueue.py
@@ -90,7 +90,7 @@ def test_caught_exception_queue_put(writer, capsys):
     assert out == ""
     assert lines[0] == "--- Logging error in Loguru Handler #0 ---"
     assert re.match(r"Record was: \{.*Bye bye.*\}", lines[1])
-    assert len(re.findall(r"You shall not serialize me!", err)) >= 2
+    assert len(re.findall(r"You shall not serialize me!", err)) == 2
     assert lines[-1] == "--- End of logging error ---"
 
 

--- a/tests/test_add_option_enqueue.py
+++ b/tests/test_add_option_enqueue.py
@@ -12,7 +12,12 @@ from .conftest import default_threading_excepthook
 
 class NotPicklable:
     def __getstate__(self):
-        raise pickle.PicklingError("You shall not serialize me!")
+        raise Exception(
+            [
+                TypeError("You shall not serialize me!"),
+                pickle.PicklingError("You shall not serialize me!"),
+            ],
+        )
 
     def __setstate__(self, state):
         pass
@@ -85,7 +90,7 @@ def test_caught_exception_queue_put(writer, capsys):
     assert out == ""
     assert lines[0] == "--- Logging error in Loguru Handler #0 ---"
     assert re.match(r"Record was: \{.*Bye bye.*\}", lines[1])
-    assert lines[-2].endswith("PicklingError: You shall not serialize me!")
+    assert len(re.findall(r"You shall not serialize me!", err)) == 2
     assert lines[-1] == "--- End of logging error ---"
 
 
@@ -129,7 +134,7 @@ def test_not_caught_exception_queue_put(writer, capsys):
 
     logger.info("It's fine")
 
-    with pytest.raises(pickle.PicklingError, match=r"You shall not serialize me!"):
+    with pytest.raises(Exception, match=r"You shall not serialize me!"):
         logger.bind(broken=NotPicklable()).info("Bye bye...")
 
     logger.remove()


### PR DESCRIPTION
Hello and thank you for this great module !

Recently I have beginning to use loguru with an 'aiohttp' project and I have beginning to encounter some annoying exception coming from loguru :

```
[...]
project  |     raise ClientResponseError(
project  | aiohttp.client_exceptions.ClientResponseError: 400, message='Expected HTTP/', url=URL('https://xxxxxxxxx')
project  | 
project  | During handling of the above exception, another exception occurred:
project  | 
project  | Traceback (most recent call last):
project  |   File "/usr/local/lib/python3.11/site-packages/loguru/_handler.py", line 195, in emit
project  |     self._queue.put(str_record)
project  |   File "/usr/local/lib/python3.11/multiprocessing/queues.py", line 371, in put
project  |     obj = _ForkingPickler.dumps(obj)
project  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
project  |   File "/usr/local/lib/python3.11/multiprocessing/reduction.py", line 51, in dumps
project  |     cls(buf, protocol).dump(obj)
project  |   File "/usr/local/lib/python3.11/site-packages/loguru/_recattrs.py", line 73, in __reduce__
project  |     pickle.dumps(self.value)
project  | TypeError: can't pickle multidict._multidict.CIMultiDictProxy objects
project  | --- End of logging error ---

```

With the proposed patch it seems to work flawlessly again.

Let me know if it seems fine to you too.