### PR TITLE
Windows 10 and above ANSI support

### DIFF
--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -52,4 +52,4 @@ def should_wrap(stream):
 def wrap(stream):
     from colorama import AnsiToWin32
 
-    return AnsiToWin32(stream, convert=True, strip=False, autoreset=False).stream
+    return AnsiToWin32(stream, convert=None, strip=None, autoreset=False).stream

--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -44,19 +44,20 @@ def should_wrap(stream):
     if stream is not sys.__stdout__ and stream is not sys.__stderr__:
         return False
 
-    try:
-        from colorama.winterm import enable_vt_processing
-
-        has_native_ansi = enable_vt_processing(stream.fileno())
-    except Exception:
-        has_native_ansi = False
-
-    if has_native_ansi:
-        return False
-
     from colorama.win32 import winapi_test
 
-    return winapi_test()
+    if not winapi_test():
+        return False
+
+    try:
+        from colorama.winterm import enable_vt_processing
+    except ImportError:
+        return True
+
+    try:
+        return not enable_vt_processing(stream.fileno())
+    except Exception:
+        return True
 
 
 def wrap(stream):

--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -62,4 +62,4 @@ def should_wrap(stream):
 def wrap(stream):
     from colorama import AnsiToWin32
 
-    return AnsiToWin32(stream, convert=None, strip=None, autoreset=False).stream
+    return AnsiToWin32(stream, convert=True, strip=False, autoreset=False).stream

--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -62,4 +62,4 @@ def should_wrap(stream):
 def wrap(stream):
     from colorama import AnsiToWin32
 
-    return AnsiToWin32(stream, convert=True, strip=False, autoreset=False).stream
+    return AnsiToWin32(stream, convert=True, strip=True, autoreset=False).stream

--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -44,6 +44,16 @@ def should_wrap(stream):
     if stream is not sys.__stdout__ and stream is not sys.__stderr__:
         return False
 
+    try:
+        from colorama.winterm import enable_vt_processing
+
+        has_native_ansi = enable_vt_processing(stream.fileno())
+    except Exception:
+        has_native_ansi = False
+
+    if has_native_ansi:
+        return False
+
     from colorama.win32 import winapi_test
 
     return winapi_test()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,18 +74,28 @@ def check_dir(dir, *, files=None, size=None):
             seen.add(filepath)
 
 
-class StreamIsattyTrue(io.StringIO):
+class StubStream(io.StringIO):
+    def fileno(self):
+        return 1
+
+
+class StreamIsattyTrue(StubStream):
     def isatty(self):
         return True
 
 
-class StreamIsattyFalse(io.StringIO):
+class StreamIsattyFalse(StubStream):
     def isatty(self):
         return False
 
 
-class StreamIsattyException(io.StringIO):
+class StreamIsattyException(StubStream):
     def isatty(self):
+        raise RuntimeError
+
+
+class StreamFilenoException(StreamIsattyTrue):
+    def fileno(self):
         raise RuntimeError
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pytest
@@ -19,7 +20,7 @@ from loguru import logger
         ("{level.icon}", lambda r: r == "🐞"),
         ("{file}", lambda r: r == "test_formatting.py"),
         ("{file.name}", lambda r: r == "test_formatting.py"),
-        ("{file.path}", lambda r: r == __file__),
+        ("{file.path}", lambda r: os.path.normcase(r) == os.path.normcase(__file__)),
         ("{function}", lambda r: r == "test_log_formatters"),
         ("{module}", lambda r: r == "test_formatting"),
         ("{thread}", lambda r: re.fullmatch(r"\d+", r)),


### PR DESCRIPTION
This pull request is a quick fix to issue #934 with little changes to the original code.

- Lets [colorama](https://github.com/tartley/colorama/blob/master/colorama/ansitowin32.py#L72) decide whether to `convert` or `strip` the ANSI sequences.