### PR TITLE
Fix STRIKE and HIDE ANSI codes

### DIFF
--- a/loguru/_colorizer.py
+++ b/loguru/_colorizer.py
@@ -10,8 +10,8 @@ class Style:
     UNDERLINE = 4
     BLINK = 5
     REVERSE = 7
-    STRIKE = 8
-    HIDE = 9
+    HIDE = 8
+    STRIKE = 9
     NORMAL = 22
 
 


### PR DESCRIPTION
The ANSI codes for STRIKE and HIDE are incorrect. According to [ANSI Escape Codes](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode) [`STRIKE`](https://github.com/Delgan/loguru/blob/d17ae011117e46365f3b68ec4eded733b8434090/loguru/_colorizer.py#L13) should be `9` and [`HIDE`](https://github.com/Delgan/loguru/blob/d17ae011117e46365f3b68ec4eded733b8434090/loguru/_colorizer.py#L14) should be `8`.