### PR TITLE
Replace flake8 and isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,13 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-  - id: isort
 - repo: https://github.com/ambv/black
   rev: 23.7.0
   hooks:
   - id: black
     args: [-l, '100', --target-version, py35]
-- repo: https://github.com/pycqa/flake8
-  rev: 6.1.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.286
   hooks:
-  - id: flake8
-    args: [--exclude, tests/exceptions/source]
-    additional_dependencies:
-    - flake8-bugbear==23.1.20
-    - pep8-naming==0.13.3
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+# Enforce isort (I), bugbears (B), and pep8-naming (N) rules
+select = ["E", "F", "I", "B", "N"]
+line-length = 100
+exclude = ["tests/exceptions/source"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
 # Enforce isort (I), bugbears (B), and pep8-naming (N) rules
-select = ["E", "F", "I", "B", "N"]
+select = ["E", "F", "W", "I", "B", "N"]
 # Ignore these errors for now that are picked up by ruff but were not by flake8
 ignore = ["B904", "B033", "B028", "B018"]
 line-length = 100
 exclude = ["tests/exceptions/source", "loguru/__init__.pyi"]
+[pycodestyle]
+max-doc-length = 100

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,6 @@
 # Enforce isort (I), bugbears (B), and pep8-naming (N) rules
 select = ["E", "F", "I", "B", "N"]
+# Ignore these errors for now that are picked up by ruff but were not by flake8
+ignore = ["B904", "B033", "B028", "B018"]
 line-length = 100
-exclude = ["tests/exceptions/source"]
+exclude = ["tests/exceptions/source", "loguru/__init__.pyi"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
-# Enforce isort (I), bugbears (B), and pep8-naming (N) rules
-select = ["E", "F", "W", "I", "B", "N"]
+# Enforce pyflakes(F), pycodestyle(E, W), isort (I), bugbears (B), and pep8-naming (N) rules
+select = ["F", "E", "W", "I", "B", "N"]
 # Ignore these errors for now that are picked up by ruff but were not by flake8
 ignore = ["B904", "B033", "B028", "B018"]
 line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -23,21 +23,6 @@ description = Build the HTML documentation.
 commands =
     sphinx-build -a -b html -W --keep-going docs/ docs/build
 
-[isort]
-line_length = 100
-profile = black
-
-[flake8]
-max_line_length = 100
-max_doc_length = 100
-ignore =
-    # Line break before binary operator (PEP8 now recommend to break after binary operator)
-    W503
-    # Whitespace before ":" in slices
-    E203
-exclude =
-    tests/exceptions/source
-
 [pytest]
 addopts = -l
 testpaths =


### PR DESCRIPTION
Fix #830 

I took on the little task of switching to ruff.
It seems to be working properly but I'm seeing a lot of [N805](https://beta.ruff.rs/docs/rules/invalid-first-argument-name-for-method/), and [B018](https://beta.ruff.rs/docs/rules/useless-expression/) errors.
There are also a handful of other B*** errors.

I'm confused by that since ruff should be reimplementing the same errors as bugbear and pep8-naming. Somehow though, ruff seems more stringent. But maybe I missed some excludes from flake8?
I did introduce a bugbear error and checked on the master branch that it got picked up by flake8 so it is running.

@Delgan What would be your preferred solution? Do you know why this might be happening?