### PR TITLE
Fix errors due to non-unpicklable Exception when "enqueue=True"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@
 - Add support for true colors on Windows using ANSI/VT console when available (`#934 <https://github.com/Delgan/loguru/issues/934>`_, thanks `@tunaflsh <https://github.com/tunaflsh>`_).
 - Fix file possibly rotating too early or too late when re-starting an application around midnight (`#894 <https://github.com/Delgan/loguru/issues/894>`_).
 - Fix inverted ``"<hide>"`` and ``"<strike>"`` color tags (`#943 <https://github.com/Delgan/loguru/pull/943>`_, thanks `@tunaflsh <https://github.com/tunaflsh>`_).
-- Fix possible errors raised by logging non-picklable ``Exception`` instances while using ``enqueue=True`` (`#342 <https://github.com/Delgan/loguru/issues/342>`_, thanks `@ncoudene <https://github.com/ncoudene>`_).
+- Fix possible untraceable errors raised when logging non-unpicklable ``Exception`` instances while using ``enqueue=True`` (`#329 <https://github.com/Delgan/loguru/issues/329>`_).
+- Fix possible errors raised when logging non-picklable ``Exception`` instances while using ``enqueue=True`` (`#342 <https://github.com/Delgan/loguru/issues/342>`_, thanks `@ncoudene <https://github.com/ncoudene>`_).
 - Fix missing seconds and microseconds when formatting timezone offset that requires such accuracy (`#961 <https://github.com/Delgan/loguru/issues/961>`_).
 - Raise ``ValueError`` if an attempt to use nanosecond precision for time formatting is detected (`#855 <https://github.com/Delgan/loguru/issues/855>`_).
 

--- a/tests/test_add_option_enqueue.py
+++ b/tests/test_add_option_enqueue.py
@@ -34,6 +34,14 @@ class NotUnpicklable:
         raise pickle.UnpicklingError("You shall not de-serialize me!")
 
 
+class NotUnpicklableTypeError:
+    def __getstate__(self):
+        return "..."
+
+    def __setstate__(self, state):
+        raise TypeError("You shall not de-serialize me!")
+
+
 class NotWritable:
     def write(self, message):
         if "fail" in message.record["extra"]:
@@ -97,24 +105,6 @@ def test_caught_exception_queue_put(writer, capsys):
     assert lines[-1] == "--- End of logging error ---"
 
 
-def test_caught_exception_queue_put_typerror(writer, capsys):
-    logger.add(writer, enqueue=True, catch=True, format="{message}")
-
-    logger.info("It's fine")
-    logger.bind(broken=NotPicklableTypeError()).info("Bye bye...")
-    logger.info("It's fine again")
-    logger.remove()
-
-    out, err = capsys.readouterr()
-    lines = err.strip().splitlines()
-    assert writer.read() == "It's fine\nIt's fine again\n"
-    assert out == ""
-    assert lines[0] == "--- Logging error in Loguru Handler #0 ---"
-    assert re.match(r"Record was: \{.*Bye bye.*\}", lines[1])
-    assert lines[-2].endswith("TypeError: You shall not serialize me!")
-    assert lines[-1] == "--- End of logging error ---"
-
-
 def test_caught_exception_queue_get(writer, capsys):
     logger.add(writer, enqueue=True, catch=True, format="{message}")
 
@@ -157,22 +147,6 @@ def test_not_caught_exception_queue_put(writer, capsys):
 
     with pytest.raises(pickle.PicklingError, match=r"You shall not serialize me!"):
         logger.bind(broken=NotPicklable()).info("Bye bye...")
-
-    logger.remove()
-
-    out, err = capsys.readouterr()
-    assert writer.read() == "It's fine\n"
-    assert out == ""
-    assert err == ""
-
-
-def test_not_caught_exception_queue_put_typeerror(writer, capsys):
-    logger.add(writer, enqueue=True, catch=False, format="{message}")
-
-    logger.info("It's fine")
-
-    with pytest.raises(TypeError, match=r"You shall not serialize me!"):
-        logger.bind(broken=NotPicklableTypeError()).info("Bye bye...")
 
     logger.remove()
 
@@ -274,7 +248,8 @@ def test_wait_for_all_messages_enqueued(capsys):
     assert err == "".join("%d\n" % i for i in range(10))
 
 
-def test_logging_not_picklable_exception():
+@pytest.mark.parametrize("exception_value", [NotPicklable(), NotPicklableTypeError()])
+def test_logging_not_picklable_exception(exception_value):
     exception = None
 
     def sink(message):
@@ -284,7 +259,7 @@ def test_logging_not_picklable_exception():
     logger.add(sink, enqueue=True, catch=False)
 
     try:
-        raise ValueError(NotPicklable())
+        raise ValueError(exception_value)
     except Exception:
         logger.exception("Oups")
 
@@ -296,8 +271,8 @@ def test_logging_not_picklable_exception():
     assert traceback_ is None
 
 
-@pytest.mark.skip(reason="No way to safely deserialize exception yet")
-def test_logging_not_unpicklable_exception():
+@pytest.mark.parametrize("exception_value", [NotUnpicklable(), NotUnpicklableTypeError()])
+def test_logging_not_unpicklable_exception(exception_value):
     exception = None
 
     def sink(message):
@@ -307,7 +282,7 @@ def test_logging_not_unpicklable_exception():
     logger.add(sink, enqueue=True, catch=False)
 
     try:
-        raise ValueError(NotUnpicklable())
+        raise ValueError(exception_value)
     except Exception:
         logger.exception("Oups")
 


### PR DESCRIPTION
Fix #329.
Fix #504.

There are instances where a custom `Exception` might contain attributes that cannot be serialized or is incorrectly implemented (see [Cannot unpickle Exception subclass](https://stackoverflow.com/questions/41808912/cannot-unpickle-exception-subclass)). If this occurs with `enqueue=True`, an error will be raised by the background thread when it calls `queue.get()`. Due to the failure of de-serialization, the `record` is `None`, resulting in an inability to identify the origin of the error.

To address this concern, we can take a proactive step by attempting to unpickle the `Exception` beforehand. In the event of a failure, we replace its value with `None` to make sure it can be unpickled. This strategy mirrors what we already do for the serialization part. Actually, this approach was already implemented in the past. However, it was temporarily removed due to concerns raised about its safety (#563). Subsequent assessments have demonstrated its complete safety, allowing us to reintroduce it. Furthermore, we have expanded its scope to encompass all types of exceptions, not solely limited to `UnpicklingError`. This broader implementation serves to mitigate the aforementioned issues effectively.