### PR TITLE
Fix possible deadlock with "complete()" and async sink

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 
 - Add a new ``context`` optional argument to ``logger.add()`` specifying ``multiprocessing`` context (like ``"spawn"`` or ``"fork"``) to be used internally instead of the default one (`#851 <https://github.com/Delgan/loguru/issues/851>`_).
 - Add support for true colors on Windows using ANSI/VT console when available (`#934 <https://github.com/Delgan/loguru/issues/934>`_, thanks `@tunaflsh <https://github.com/tunaflsh>`_).
+- Fix possible deadlock when calling ``logger.complete()`` with concurrent logging of an asynchronous sink (`#906 <https://github.com/Delgan/loguru/issues/906>`_).
 - Fix file possibly rotating too early or too late when re-starting an application around midnight (`#894 <https://github.com/Delgan/loguru/issues/894>`_).
 - Fix inverted ``"<hide>"`` and ``"<strike>"`` color tags (`#943 <https://github.com/Delgan/loguru/pull/943>`_, thanks `@tunaflsh <https://github.com/tunaflsh>`_).
 - Fix possible untraceable errors raised when logging non-unpicklable ``Exception`` instances while using ``enqueue=True`` (`#329 <https://github.com/Delgan/loguru/issues/329>`_).

--- a/loguru/_file_sink.py
+++ b/loguru/_file_sink.py
@@ -211,8 +211,8 @@ class FileSink:
 
         self._terminate_file(is_rotating=False)
 
-    async def complete(self):
-        pass
+    def tasks_to_complete(self):
+        return []
 
     def _create_path(self):
         path = self._path.format_map({"time": FileDateFormatter()})

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -69,6 +69,7 @@ class Handler:
         self._lock = create_handler_lock()
         self._lock_acquired = threading.local()
         self._queue = None
+        self._queue_lock = None
         self._confirmation_event = None
         self._confirmation_lock = None
         self._owner_process_pid = None
@@ -88,6 +89,7 @@ class Handler:
 
         if self._enqueue:
             self._queue = self._multiprocessing_context.SimpleQueue()
+            self._queue_lock = create_handler_lock()
             self._confirmation_event = self._multiprocessing_context.Event()
             self._confirmation_lock = self._multiprocessing_context.Lock()
             self._owner_process_pid = os.getpid()
@@ -223,12 +225,12 @@ class Handler:
             self._confirmation_event.wait()
             self._confirmation_event.clear()
 
-    async def complete_async(self):
+    def tasks_to_complete(self):
         if self._enqueue and self._owner_process_pid != os.getpid():
-            return
-
-        with self._protected_lock():
-            await self._sink.complete()
+            return []
+        lock = self._queue_lock if self._enqueue else self._protected_lock()
+        with lock:
+            return self._sink.tasks_to_complete()
 
     def update_format(self, level_id):
         if not self._colorize or self._is_formatter_dynamic:
@@ -285,7 +287,7 @@ class Handler:
 
         # We need to use a lock to protect sink during fork.
         # Particularly, writing to stderr may lead to deadlock in child process.
-        lock = create_handler_lock()
+        lock = self._queue_lock
 
         while True:
             try:
@@ -317,12 +319,15 @@ class Handler:
             state["_sink"] = None
             state["_thread"] = None
             state["_owner_process"] = None
+            state["_queue_lock"] = None
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._lock = create_handler_lock()
         self._lock_acquired = threading.local()
+        if self._enqueue:
+            self._queue_lock = create_handler_lock()
         if self._is_formatter_dynamic:
             if self._colorize:
                 self._memoize_dynamic_format = memoize(prepare_colored_format)


### PR DESCRIPTION
Fix #906.

Small refactor to avoid using `await` while a `Lock` is acquired.