### PR TITLE
Remove the noqa and adjust test reference files

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 # Enforce pyflakes(F), pycodestyle(E, W), isort (I), bugbears (B), and pep8-naming (N) rules
 select = ["F", "E", "W", "I", "B", "N"]
 line-length = 100
-exclude = ["tests/exceptions/source"]
+exclude = ["tests/exceptions/source/*"]
 [pycodestyle]
 max-doc-length = 100

--- a/tests/exceptions/output/diagnose/attributes.txt
+++ b/tests/exceptions/output/diagnose/attributes.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mattributes.py[0m", line [33m27[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mattributes.py[0m", line [33m26[0m, in [35m<module>[0m
     [1mfoo[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function foo at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mattributes.py[0m", line [33m23[0m, in [35mfoo[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mattributes.py[0m", line [33m22[0m, in [35mfoo[0m
     [35m[1m...[0m [35m[1m+[0m [34m[1m1[0m [35m[1m+[0m [1mbar[0m[1m([0m[1ma[0m[1m)[0m[35m[1m.[0m[1mb[0m [35m[1m+[0m [1ma[0m[35m[1m.[0m[1mforbidden[0m [35m[1m+[0m [1ma[0m[35m[1m.[0m[1mnope[0m[35m[1m.[0m[1ma[0m [35m[1m+[0m [1mx[0m[35m[1m.[0m[1m__bool__[0m [35m[1mor[0m [1ma[0m[35m[1m.[0m [1mb[0m [35m[1m.[0m [1misdigit[0m[1m([0m[1m)[0m [35m[1mand[0m [34m[1m.3[0m [35m[1m+[0m [35m[1m...[0m
     [36m              │      │ │           │          │ │           │  │   └ [0m[36m[1m<method 'isdigit' of 'str' objects>[0m
     [36m              │      │ │           │          │ │           │  └ [0m[36m[1m'123'[0m

--- a/tests/exceptions/output/diagnose/parenthesis.txt
+++ b/tests/exceptions/output/diagnose/parenthesis.txt
@@ -1,16 +1,16 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m48[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m47[0m, in [35m<module>[0m
     [1me[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function e at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m44[0m, in [35me[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m43[0m, in [35me[0m
     [1m)[0m [35m[1m+[0m [1md[0m[1m([0m[1m([0m[1m)[0m[1m)[0m [35m[1m+[0m [1ma[0m
     [36m    │       └ [0m[36m[1m1[0m
     [36m    └ [0m[36m[1m<function d at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m37[0m, in [35md[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m36[0m, in [35md[0m
     [1m;[0m [1mz[0m [35m[1m=[0m [1m([0m[1mx[0m [35m[1m*[0m [1my[0m[1m)[0m[1m;[0m [1my[0m [35m[1m=[0m [1m([0m[1mj[0m [35m[1mor[0m [1mxyz[0m[35m[1m.[0m[1mval[0m [35m[1m*[0m [1mc[0m[1m([0m[1m)[0m \
     [36m  │    │   │   │    │    │   │     └ [0m[36m[1m<function c at 0xDEADBEEF>[0m
     [36m  │    │   │   │    │    │   └ [0m[36m[1m123[0m
@@ -21,20 +21,20 @@
     [36m  │    └ [0m[36m[1m2[0m
     [36m  └ [0m[36m[1m10[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m29[0m, in [35mc[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m28[0m, in [35mc[0m
     [1mx[0m[35m[1m.[0m[1mval[0m [35m[1m+=[0m [34m[1m456[0m [35m[1mand[0m [1mb[0m[1m([0m[1m)[0m
     [36m│ │              └ [0m[36m[1m<function b at 0xDEADBEEF>[0m
     [36m│ └ [0m[36m[1m123[0m
     [36m└ [0m[36m[1m<__main__.XYZ object at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m23[0m, in [35mb[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m22[0m, in [35mb[0m
     [1mfoo[0m[1m[[0m[1m([0m[36m"baz"[0m[1m)[0m[1m][0m [35m[1m=[0m [1mbar[0m[1m([0m[1m)[0m [35m[1m+[0m [1m([0m[1ma[0m[1m([0m[34m[1m5[0m[1m,[0m [1mbaz[0m[1m)[0m[1m)[0m
     [36m│              │        │    └ [0m[36m[1m0[0m
     [36m│              │        └ [0m[36m[1m<function a at 0xDEADBEEF>[0m
     [36m│              └ [0m[36m[1m<class '__main__.XYZ'>[0m
     [36m└ [0m[36m[1m{}[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m18[0m, in [35ma[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1mparenthesis.py[0m", line [33m17[0m, in [35ma[0m
     [1m([0m[1ma[0m[1m,[0m [1mb[0m[1m,[0m [1mx[0m[35m[1m.[0m[1mval[0m[1m,[0m [1m)[0m [35m[1m=[0m [34m[1m12[0m[1m,[0m [34m[1m15[0m [35m[1m/[0m [1mc[0m[1m,[0m [34m[1m17[0m
     [36m │  │  │ │                 └ [0m[36m[1m0[0m
     [36m │  │  │ └ [0m[36m[1m9[0m

--- a/tests/exceptions/output/diagnose/source_multilines.txt
+++ b/tests/exceptions/output/diagnose/source_multilines.txt
@@ -1,23 +1,23 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m40[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m39[0m, in [35m<module>[0m
     [1mbug_1[0m[1m([0m[34m[1m10[0m[1m)[0m
     [36m└ [0m[36m[1m<function bug_1 at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m13[0m, in [35mbug_1[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m12[0m, in [35mbug_1[0m
     """ + n / 0)
 
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m46[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m45[0m, in [35m<module>[0m
     [1mbug_2[0m[1m([0m[34m[1m1[0m[1m,[0m [1mstring[0m[1m,[0m [34m[1m3[0m[1m)[0m
     [36m│        └ [0m[36m[1m'multi-lines\n'[0m
     [36m└ [0m[36m[1m<function bug_2 at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m17[0m, in [35mbug_2[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m16[0m, in [35mbug_2[0m
     [35m[1mreturn[0m [1m([0m[34m[1m1[0m [35m[1m/[0m [34m[1m0[0m [35m[1m+[0m [1ma[0m [35m[1m+[0m [1mb[0m [35m[1m+[0m \
     [36m                │   └ [0m[36m[1m'multi-lines\n'[0m
     [36m                └ [0m[36m[1m1[0m
@@ -26,12 +26,12 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m52[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m51[0m, in [35m<module>[0m
     [1mbug_3[0m[1m([0m[1mstring[0m[1m)[0m
     [36m│     └ [0m[36m[1m'multi-lines\n'[0m
     [36m└ [0m[36m[1m<function bug_3 at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m23[0m, in [35mbug_3[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m22[0m, in [35mbug_3[0m
     [1m,[0m [1mstring[0m[1m,[0m [34m[1m20[0m [35m[1m/[0m [34m[1m0[0m[1m)[0m
     [36m  └ [0m[36m[1m'multi-lines\n'[0m
 
@@ -39,11 +39,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m58[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m57[0m, in [35m<module>[0m
     [1mbug_4[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function bug_4 at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m30[0m, in [35mbug_4[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msource_multilines.py[0m", line [33m29[0m, in [35mbug_4[0m
     [36m"bar"[0m[1m:[0m [1ma[0m [35m[1m/[0m [1mb[0m[1m,[0m
     [36m       │   └ [0m[36m[1m0[0m
     [36m       └ [0m[36m[1m1[0m

--- a/tests/exceptions/output/diagnose/syntax_highlighting.txt
+++ b/tests/exceptions/output/diagnose/syntax_highlighting.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m32[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m31[0m, in [35m<module>[0m
     [1me[0m[1m([0m[34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function e at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m28[0m, in [35me[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m27[0m, in [35me[0m
     [1mx[0m [35m[1min[0m [1m[[0m[34m[1m1[0m[1m][0m[1m,[0m [1mx[0m [35m[1min[0m [1m([0m[34m[1m1[0m[1m,[0m[1m)[0m[1m,[0m [1mx[0m [35m[1min[0m [1m{[0m[34m[1m1[0m[1m}[0m[1m,[0m [1mx[0m [35m[1min[0m [1m{[0m[34m[1m1[0m[1m:[0m [34m[1m1[0m[1m}[0m[1m,[0m [1md[0m[1m([0m[1m)[0m
     [36m│         │          │         │            └ [0m[36m[1m<function d at 0xDEADBEEF>[0m
     [36m│         │          │         └ [0m[36m[1m0[0m
@@ -13,19 +13,19 @@
     [36m│         └ [0m[36m[1m0[0m
     [36m└ [0m[36m[1m0[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m24[0m, in [35md[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m23[0m, in [35md[0m
     [1mmin[0m[1m([0m[1mrange[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m10[0m[1m)[0m[1m)[0m[1m,[0m [1mlist[0m[1m([0m[1m)[0m[1m,[0m [1mdict[0m[1m([0m[1m)[0m[1m,[0m [1mc[0m[1m([0m[1m)[0m[1m,[0m [35m[1m...[0m
     [36m                                   └ [0m[36m[1m<function c at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m20[0m, in [35mc[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m19[0m, in [35mc[0m
     [34m[1m1[0m[1m,[0m [34m[1m2.5[0m[1m,[0m [34m[1m3.0[0m[1m,[0m [34m[1m0.4[0m[1m,[0m [36m"str"[0m[1m,[0m [36mr"rrr"[0m[1m,[0m [36mrb"binary"[0m[1m,[0m [1mb[0m[1m([0m[1m)[0m
     [36m                                             └ [0m[36m[1m<function b at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m16[0m, in [35mb[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m15[0m, in [35mb[0m
     [1ma[0m[1m([0m[1m)[0m [35m[1mor[0m [36m[1mFalse[0m [35m[1m==[0m [36m[1mNone[0m [35m[1m!=[0m [36m[1mTrue[0m
     [36m└ [0m[36m[1m<function a at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m12[0m, in [35ma[0m
+  File "[32mtests/exceptions/source/diagnose/[0m[32m[1msyntax_highlighting.py[0m", line [33m11[0m, in [35ma[0m
     [34m[1m1[0m [35m[1m/[0m [34m[1m0[0m [35m[1m+[0m [34m[1m1[0m [35m[1m*[0m [34m[1m0[0m [35m[1m-[0m [34m[1m1[0m [35m[1m%[0m [34m[1m0[0m [35m[1m//[0m [34m[1m1[0m[35m[1m**[0m[34m[1m0[0m [35m[1m@[0m [34m[1m1[0m  [30m[1m# Error[0m
 
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m

--- a/tests/exceptions/output/others/exception_in_property.txt
+++ b/tests/exceptions/output/others/exception_in_property.txt
@@ -1,12 +1,12 @@
 
 Traceback (most recent call last):
 
-  File "tests/exceptions/source/others/exception_in_property.py", line 23, in <module>
+  File "tests/exceptions/source/others/exception_in_property.py", line 22, in <module>
     value = a.value
             │ └ <property object at 0xDEADBEEF>
             └ <__main__.A object at 0xDEADBEEF>
 
-> File "tests/exceptions/source/others/exception_in_property.py", line 14, in value
+> File "tests/exceptions/source/others/exception_in_property.py", line 13, in value
     1 / 0
 
 ZeroDivisionError: division by zero

--- a/tests/exceptions/output/others/nested_with_reraise.txt
+++ b/tests/exceptions/output/others/nested_with_reraise.txt
@@ -1,20 +1,20 @@
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
     f = foo(x, y)
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
     a / b
 ZeroDivisionError: division by zero
 
 Traceback (most recent call last):
 
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
     f = foo(x, y)
         │   │  └ 0
         │   └ 1
         └ <function foo at 0xDEADBEEF>
 
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
     a / b
     │   └ 0
     └ 1
@@ -22,133 +22,133 @@ Traceback (most recent call last):
 ZeroDivisionError: division by zero
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 31, in <module>
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 30, in <module>
     baz()
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 27, in baz
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 26, in baz
     bar(1, 0)
-> File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
+> File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
     f = foo(x, y)
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
     a / b
 ZeroDivisionError: division by zero
 
 Traceback (most recent call last):
 
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 31, in <module>
-    baz()
-    └ <function baz at 0xDEADBEEF>
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 27, in baz
-    bar(1, 0)
-    └ <function bar at 0xDEADBEEF>
-
-> File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
-    f = foo(x, y)
-        │   │  └ 0
-        │   └ 1
-        └ <function foo at 0xDEADBEEF>
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
-    a / b
-    │   └ 0
-    └ 1
-
-ZeroDivisionError: division by zero
-
-Traceback (most recent call last):
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
-    f = foo(x, y)
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
-    a / b
-ZeroDivisionError: division by zero
-
-The above exception was the direct cause of the following exception:
-
-Traceback (most recent call last):
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 27, in baz
-    bar(1, 0)
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 23, in bar
-    raise ValueError from e
-ValueError
-
-Traceback (most recent call last):
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
-    f = foo(x, y)
-        │   │  └ 0
-        │   └ 1
-        └ <function foo at 0xDEADBEEF>
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
-    a / b
-    │   └ 0
-    └ 1
-
-ZeroDivisionError: division by zero
-
-
-The above exception was the direct cause of the following exception:
-
-
-Traceback (most recent call last):
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 27, in baz
-    bar(1, 0)
-    └ <function bar at 0xDEADBEEF>
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 23, in bar
-    raise ValueError from e
-
-ValueError
-
-Traceback (most recent call last):
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
-    f = foo(x, y)
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
-    a / b
-ZeroDivisionError: division by zero
-
-The above exception was the direct cause of the following exception:
-
-Traceback (most recent call last):
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 31, in <module>
-    baz()
-> File "tests/exceptions/source/others/nested_with_reraise.py", line 27, in baz
-    bar(1, 0)
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 23, in bar
-    raise ValueError from e
-ValueError
-
-Traceback (most recent call last):
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 21, in bar
-    f = foo(x, y)
-        │   │  └ 0
-        │   └ 1
-        └ <function foo at 0xDEADBEEF>
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 15, in foo
-    a / b
-    │   └ 0
-    └ 1
-
-ZeroDivisionError: division by zero
-
-
-The above exception was the direct cause of the following exception:
-
-
-Traceback (most recent call last):
-
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 31, in <module>
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 30, in <module>
     baz()
     └ <function baz at 0xDEADBEEF>
 
-> File "tests/exceptions/source/others/nested_with_reraise.py", line 27, in baz
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 26, in baz
     bar(1, 0)
     └ <function bar at 0xDEADBEEF>
 
-  File "tests/exceptions/source/others/nested_with_reraise.py", line 23, in bar
+> File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
+    f = foo(x, y)
+        │   │  └ 0
+        │   └ 1
+        └ <function foo at 0xDEADBEEF>
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
+    a / b
+    │   └ 0
+    └ 1
+
+ZeroDivisionError: division by zero
+
+Traceback (most recent call last):
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
+    f = foo(x, y)
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
+    a / b
+ZeroDivisionError: division by zero
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 26, in baz
+    bar(1, 0)
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 22, in bar
+    raise ValueError from e
+ValueError
+
+Traceback (most recent call last):
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
+    f = foo(x, y)
+        │   │  └ 0
+        │   └ 1
+        └ <function foo at 0xDEADBEEF>
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
+    a / b
+    │   └ 0
+    └ 1
+
+ZeroDivisionError: division by zero
+
+
+The above exception was the direct cause of the following exception:
+
+
+Traceback (most recent call last):
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 26, in baz
+    bar(1, 0)
+    └ <function bar at 0xDEADBEEF>
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 22, in bar
+    raise ValueError from e
+
+ValueError
+
+Traceback (most recent call last):
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
+    f = foo(x, y)
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
+    a / b
+ZeroDivisionError: division by zero
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 30, in <module>
+    baz()
+> File "tests/exceptions/source/others/nested_with_reraise.py", line 26, in baz
+    bar(1, 0)
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 22, in bar
+    raise ValueError from e
+ValueError
+
+Traceback (most recent call last):
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 20, in bar
+    f = foo(x, y)
+        │   │  └ 0
+        │   └ 1
+        └ <function foo at 0xDEADBEEF>
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 14, in foo
+    a / b
+    │   └ 0
+    └ 1
+
+ZeroDivisionError: division by zero
+
+
+The above exception was the direct cause of the following exception:
+
+
+Traceback (most recent call last):
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 30, in <module>
+    baz()
+    └ <function baz at 0xDEADBEEF>
+
+> File "tests/exceptions/source/others/nested_with_reraise.py", line 26, in baz
+    bar(1, 0)
+    └ <function bar at 0xDEADBEEF>
+
+  File "tests/exceptions/source/others/nested_with_reraise.py", line 22, in bar
     raise ValueError from e
 
 ValueError

--- a/tests/exceptions/output/ownership/assertion_from_lib.txt
+++ b/tests/exceptions/output/ownership/assertion_from_lib.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m21[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m20[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m16[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m15[0m, in [35mtest[0m
     [1massertionerror[0m[1m([0m[1ma[0m[1m,[0m [1mb[0m[1m)[0m
     [36m│              │  └ [0m[36m[1m2[0m
     [36m│              └ [0m[36m[1m1[0m
@@ -20,7 +20,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m16[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m15[0m, in [35mtest[0m
     [1massertionerror[0m[1m([0m[1ma[0m[1m,[0m [1mb[0m[1m)[0m
     [36m│              │  └ [0m[36m[1m2[0m
     [36m│              └ [0m[36m[1m1[0m
@@ -34,23 +34,23 @@
 [31m[1mAssertionError[0m: [35m[1massert[0m [1mx[0m [35m[1m==[0m [1my[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m23[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m22[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m16[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m15[0m, in [35mtest[0m
     [1massertionerror[0m[1m([0m[1ma[0m[1m,[0m [1mb[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 22, in assertionerror
     assert x == y
 [31m[1mAssertionError[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m16[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_lib.py[0m", line [33m15[0m, in [35mtest[0m
     [1massertionerror[0m[1m([0m[1ma[0m[1m,[0m [1mb[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 22, in assertionerror
     assert x == y
 [31m[1mAssertionError[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/assertion_from_lib.py", line 16, in test
+  File "tests/exceptions/source/ownership/assertion_from_lib.py", line 15, in test
     assertionerror(a, b)
   File "/usr/lib/python/somelib/__init__.py", line 22, in assertionerror
     assert x == y

--- a/tests/exceptions/output/ownership/assertion_from_local.txt
+++ b/tests/exceptions/output/ownership/assertion_from_local.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m21[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m20[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m16[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m15[0m, in [35mtest[0m
     [35m[1massert[0m [1ma[0m [35m[1m==[0m [1mb[0m
     [36m       │    └ [0m[36m[1m2[0m
     [36m       └ [0m[36m[1m1[0m
@@ -14,7 +14,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m16[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m15[0m, in [35mtest[0m
     [35m[1massert[0m [1ma[0m [35m[1m==[0m [1mb[0m
     [36m       │    └ [0m[36m[1m2[0m
     [36m       └ [0m[36m[1m1[0m
@@ -22,18 +22,18 @@
 [31m[1mAssertionError[0m: [35m[1massert[0m [1ma[0m [35m[1m==[0m [1mb[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m23[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m22[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m16[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m15[0m, in [35mtest[0m
     [35m[1massert[0m [1ma[0m [35m[1m==[0m [1mb[0m
 [31m[1mAssertionError[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m16[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1massertion_from_local.py[0m", line [33m15[0m, in [35mtest[0m
     [35m[1massert[0m [1ma[0m [35m[1m==[0m [1mb[0m
 [31m[1mAssertionError[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/assertion_from_local.py", line 16, in test
+  File "tests/exceptions/source/ownership/assertion_from_local.py", line 15, in test
     assert a == b
 AssertionError

--- a/tests/exceptions/output/ownership/callback.txt
+++ b/tests/exceptions/output/ownership/callback.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m23[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m22[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m18[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m17[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
     [36m│      └ [0m[36m[1m<function test.<locals>.callback at 0xDEADBEEF>[0m
     [36m└ [0m[36m[1m<function callme at 0xDEADBEEF>[0m
@@ -14,7 +14,7 @@
     callback()
     └ <function test.<locals>.callback at 0xDEADBEEF>
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m15[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m14[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -27,7 +27,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m18[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m17[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
     [36m│      └ [0m[36m[1m<function test.<locals>.callback at 0xDEADBEEF>[0m
     [36m└ [0m[36m[1m<function callme at 0xDEADBEEF>[0m
@@ -36,7 +36,7 @@
     callback()
     └ <function test.<locals>.callback at 0xDEADBEEF>
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m15[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m14[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -48,35 +48,35 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m25[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m24[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m18[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m17[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m15[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m14[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m18[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m17[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m15[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcallback.py[0m", line [33m14[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/callback.py", line 18, in test
+  File "tests/exceptions/source/ownership/callback.py", line 17, in test
     callme(callback)
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "tests/exceptions/source/ownership/callback.py", line 15, in callback
+  File "tests/exceptions/source/ownership/callback.py", line 14, in callback
     divide(1, 0)
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y

--- a/tests/exceptions/output/ownership/catch_decorator.txt
+++ b/tests/exceptions/output/ownership/catch_decorator.txt
@@ -1,15 +1,15 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m21[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m20[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m18[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m17[0m, in [35mtest[0m
     [1mfoo[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function test.<locals>.foo at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m16[0m, in [35mfoo[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m15[0m, in [35mfoo[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -22,11 +22,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m18[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m17[0m, in [35mtest[0m
     [1mfoo[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function test.<locals>.foo at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m16[0m, in [35mfoo[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m15[0m, in [35mfoo[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -38,29 +38,29 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m23[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m22[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m18[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m17[0m, in [35mtest[0m
     [1mfoo[0m[1m([0m[1m)[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m16[0m, in [35mfoo[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m15[0m, in [35mfoo[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m18[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m17[0m, in [35mtest[0m
     [1mfoo[0m[1m([0m[1m)[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m16[0m, in [35mfoo[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator.py[0m", line [33m15[0m, in [35mfoo[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/catch_decorator.py", line 18, in test
+  File "tests/exceptions/source/ownership/catch_decorator.py", line 17, in test
     foo()
-  File "tests/exceptions/source/ownership/catch_decorator.py", line 16, in foo
+  File "tests/exceptions/source/ownership/catch_decorator.py", line 15, in foo
     divide(1, 0)
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y

--- a/tests/exceptions/output/ownership/catch_decorator_from_lib.txt
+++ b/tests/exceptions/output/ownership/catch_decorator_from_lib.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m21[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m20[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m18[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m17[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
     [36m│      └ [0m[36m[1m<function test.<locals>.callback at 0xDEADBEEF>[0m
     [36m└ [0m[36m[1m<function callme at 0xDEADBEEF>[0m
@@ -14,7 +14,7 @@
     callback()
     └ <function test.<locals>.callback at 0xDEADBEEF>
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m16[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m15[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -31,7 +31,7 @@
     callback()
     └ <function test.<locals>.callback at 0xDEADBEEF>
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m16[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m15[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -43,13 +43,13 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m23[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m22[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m18[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m17[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
 > File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m16[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m15[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
@@ -58,7 +58,7 @@
 [33m[1mTraceback (most recent call last):[0m
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m16[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mcatch_decorator_from_lib.py[0m", line [33m15[0m, in [35mcallback[0m
     [1mdivide[0m[1m([0m[34m[1m1[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
@@ -67,7 +67,7 @@
 Traceback (most recent call last):
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "tests/exceptions/source/ownership/catch_decorator_from_lib.py", line 16, in callback
+  File "tests/exceptions/source/ownership/catch_decorator_from_lib.py", line 15, in callback
     divide(1, 0)
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y

--- a/tests/exceptions/output/ownership/decorated_callback.txt
+++ b/tests/exceptions/output/ownership/decorated_callback.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m22[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m21[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m19[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m18[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
     [36m│      └ [0m[36m[1m<function test.<locals>.callback at 0xDEADBEEF>[0m
     [36m└ [0m[36m[1m<function callme at 0xDEADBEEF>[0m
@@ -14,7 +14,7 @@
     callback()
     └ <function test.<locals>.callback at 0xDEADBEEF>
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m17[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m16[0m, in [35mcallback[0m
     [1ma[0m [35m[1m/[0m [1mb[0m
     [36m│   └ [0m[36m[1m0[0m
     [36m└ [0m[36m[1m1[0m
@@ -27,7 +27,7 @@
     callback()
     └ <function test.<locals>.callback at 0xDEADBEEF>
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m17[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m16[0m, in [35mcallback[0m
     [1ma[0m [35m[1m/[0m [1mb[0m
     [36m│   └ [0m[36m[1m0[0m
     [36m└ [0m[36m[1m1[0m
@@ -35,26 +35,26 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m24[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m23[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m19[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m18[0m, in [35mtest[0m
     [1mcallme[0m[1m([0m[1mcallback[0m[1m)[0m
 > File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m17[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m16[0m, in [35mcallback[0m
     [1ma[0m [35m[1m/[0m [1mb[0m
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m17[0m, in [35mcallback[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdecorated_callback.py[0m", line [33m16[0m, in [35mcallback[0m
     [1ma[0m [35m[1m/[0m [1mb[0m
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 Traceback (most recent call last):
   File "/usr/lib/python/somelib/__init__.py", line 10, in callme
     callback()
-  File "tests/exceptions/source/ownership/decorated_callback.py", line 17, in callback
+  File "tests/exceptions/source/ownership/decorated_callback.py", line 16, in callback
     a / b
 ZeroDivisionError: division by zero

--- a/tests/exceptions/output/ownership/direct.txt
+++ b/tests/exceptions/output/ownership/direct.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m20[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m19[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -18,7 +18,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide at 0xDEADBEEF>[0m
 
@@ -30,23 +30,23 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m22[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m21[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mdirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/direct.py", line 15, in test
+  File "tests/exceptions/source/ownership/direct.py", line 14, in test
     divide(10, 0)
   File "/usr/lib/python/somelib/__init__.py", line 2, in divide
     x / y

--- a/tests/exceptions/output/ownership/indirect.txt
+++ b/tests/exceptions/output/ownership/indirect.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m20[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m19[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide_indirect[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide_indirect at 0xDEADBEEF>[0m
 
@@ -23,7 +23,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide_indirect[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
     [36m└ [0m[36m[1m<function divide_indirect at 0xDEADBEEF>[0m
 
@@ -40,9 +40,9 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m22[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m21[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide_indirect[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 6, in divide_indirect
     divide(a, b)
@@ -51,7 +51,7 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mindirect.py[0m", line [33m14[0m, in [35mtest[0m
     [1mdivide_indirect[0m[1m([0m[34m[1m10[0m[1m,[0m [34m[1m0[0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 6, in divide_indirect
     divide(a, b)
@@ -60,7 +60,7 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/indirect.py", line 15, in test
+  File "tests/exceptions/source/ownership/indirect.py", line 14, in test
     divide_indirect(10, 0)
   File "/usr/lib/python/somelib/__init__.py", line 6, in divide_indirect
     divide(a, b)

--- a/tests/exceptions/output/ownership/string_lib.txt
+++ b/tests/exceptions/output/ownership/string_lib.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m20[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m19[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m14[0m, in [35mtest[0m
     [1mexecute[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function execute at 0xDEADBEEF>[0m
 
@@ -21,7 +21,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m14[0m, in [35mtest[0m
     [1mexecute[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function execute at 0xDEADBEEF>[0m
 
@@ -36,9 +36,9 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m22[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m21[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m14[0m, in [35mtest[0m
     [1mexecute[0m[1m([0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 14, in execute
     exec("divide(1, 0)")
@@ -48,7 +48,7 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1mstring_lib.py[0m", line [33m14[0m, in [35mtest[0m
     [1mexecute[0m[1m([0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 14, in execute
     exec("divide(1, 0)")
@@ -58,7 +58,7 @@
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/string_lib.py", line 15, in test
+  File "tests/exceptions/source/ownership/string_lib.py", line 14, in test
     execute()
   File "/usr/lib/python/somelib/__init__.py", line 14, in execute
     exec("divide(1, 0)")

--- a/tests/exceptions/output/ownership/syntaxerror.txt
+++ b/tests/exceptions/output/ownership/syntaxerror.txt
@@ -1,11 +1,11 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m20[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m19[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mTrue[0m[1m)[0m
     [36m└ [0m[36m[1m<function test at 0xDEADBEEF>[0m
 
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m14[0m, in [35mtest[0m
     [1msyntaxerror[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function syntaxerror at 0xDEADBEEF>[0m
 
@@ -19,7 +19,7 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m14[0m, in [35mtest[0m
     [1msyntaxerror[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function syntaxerror at 0xDEADBEEF>[0m
 
@@ -32,9 +32,9 @@
 [31m[1mSyntaxError[0m:[1m invalid syntax[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m22[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m21[0m, in [35m<module>[0m
     [1mtest[0m[1m([0m[1mbacktrace[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mcolorize[0m[35m[1m=[0m[36m[1mTrue[0m[1m,[0m [1mdiagnose[0m[35m[1m=[0m[36m[1mFalse[0m[1m)[0m
-> File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m15[0m, in [35mtest[0m
+> File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m14[0m, in [35mtest[0m
     [1msyntaxerror[0m[1m([0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 18, in syntaxerror
     exec("foo =")
@@ -44,7 +44,7 @@
 [31m[1mSyntaxError[0m:[1m invalid syntax[0m
 
 [33m[1mTraceback (most recent call last):[0m
-  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m15[0m, in [35mtest[0m
+  File "[32mtests/exceptions/source/ownership/[0m[32m[1msyntaxerror.py[0m", line [33m14[0m, in [35mtest[0m
     [1msyntaxerror[0m[1m([0m[1m)[0m
   File "/usr/lib/python/somelib/__init__.py", line 18, in syntaxerror
     exec("foo =")
@@ -54,7 +54,7 @@
 [31m[1mSyntaxError[0m:[1m invalid syntax[0m
 
 Traceback (most recent call last):
-  File "tests/exceptions/source/ownership/syntaxerror.py", line 15, in test
+  File "tests/exceptions/source/ownership/syntaxerror.py", line 14, in test
     syntaxerror()
   File "/usr/lib/python/somelib/__init__.py", line 18, in syntaxerror
     exec("foo =")

--- a/tests/exceptions/source/diagnose/attributes.py
+++ b/tests/exceptions/source/diagnose/attributes.py
@@ -1,5 +1,4 @@
 # fmt: off
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/diagnose/parenthesis.py
+++ b/tests/exceptions/source/diagnose/parenthesis.py
@@ -1,5 +1,4 @@
 # fmt: off
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/diagnose/source_multilines.py
+++ b/tests/exceptions/source/diagnose/source_multilines.py
@@ -1,5 +1,4 @@
 # fmt: off
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/diagnose/syntax_highlighting.py
+++ b/tests/exceptions/source/diagnose/syntax_highlighting.py
@@ -1,5 +1,4 @@
 # fmt: off
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/others/assertionerror_without_traceback.py
+++ b/tests/exceptions/source/others/assertionerror_without_traceback.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/others/exception_in_property.py
+++ b/tests/exceptions/source/others/exception_in_property.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/others/nested_with_reraise.py
+++ b/tests/exceptions/source/others/nested_with_reraise.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 from loguru import logger

--- a/tests/exceptions/source/ownership/assertion_from_lib.py
+++ b/tests/exceptions/source/ownership/assertion_from_lib.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/assertion_from_local.py
+++ b/tests/exceptions/source/ownership/assertion_from_local.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/callback.py
+++ b/tests/exceptions/source/ownership/callback.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/catch_decorator.py
+++ b/tests/exceptions/source/ownership/catch_decorator.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/catch_decorator_from_lib.py
+++ b/tests/exceptions/source/ownership/catch_decorator_from_lib.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/decorated_callback.py
+++ b/tests/exceptions/source/ownership/decorated_callback.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/direct.py
+++ b/tests/exceptions/source/ownership/direct.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/indirect.py
+++ b/tests/exceptions/source/ownership/indirect.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/string_lib.py
+++ b/tests/exceptions/source/ownership/string_lib.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init

--- a/tests/exceptions/source/ownership/syntaxerror.py
+++ b/tests/exceptions/source/ownership/syntaxerror.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 import sys
 
 import _init


### PR DESCRIPTION
[As planned](https://github.com/Delgan/loguru/pull/955#issuecomment-1695380302) I removed the `flake8: noqa` from the top of the files that had it.

I was surprised to see that the tests failed till I realized that the change in line number would affect the expected exception strings.
Oh well, a little bit of editing later and it's corrected.
I'd love to know how you make these `.txt` files with the expected output. I'm happy to document the process too if you want in CONTRIBUTING.
For this time around though the editing may have been more straight forward.