### PR TITLE
Don't set system default multiprocessing.context

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -92,7 +92,7 @@ import sys
 import warnings
 from collections import namedtuple
 from inspect import isclass, iscoroutinefunction, isgeneratorfunction
-from multiprocessing import current_process, get_context
+from multiprocessing import current_process, get_all_start_methods, get_context, get_start_method
 from multiprocessing.context import BaseContext
 from os.path import basename, splitext
 from threading import current_thread
@@ -967,8 +967,13 @@ class Logger:
         if not isinstance(encoding, str):
             encoding = "ascii"
 
-        if context is None or isinstance(context, str):
+        if isinstance(context, str):
             context = get_context(context)
+        elif context is None:
+            start_method = get_start_method(allow_none=True)
+            if start_method is None:
+                start_method = "fork" if "fork" in get_all_start_methods() else "spawn"
+            context = get_context(start_method)
         elif not isinstance(context, BaseContext):
             raise TypeError(
                 "Invalid context, it should be a string or a multiprocessing context, "


### PR DESCRIPTION
Create a new context using either the default method or the already set start method in multiprocessing.get_context, to avoid setting the default context while initializing the default handler.

Fix: https://github.com/Delgan/loguru/issues/974