### PR TITLE
Add tested support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
+        - 3.12-dev
         - pypy-3.9
         include:
         - os: ubuntu-20.04

--- a/loguru/_better_exceptions.py
+++ b/loguru/_better_exceptions.py
@@ -85,7 +85,7 @@ class SyntaxHighlighter:
             _, end_column = end
 
             if start_row != row:
-                source = source[:column]
+                source = source[column:]
                 row, column = start_row, 0
 
             if type_ != tokenize.ENCODING:

--- a/loguru/_datetime.py
+++ b/loguru/_datetime.py
@@ -94,7 +94,9 @@ def aware_now():
         seconds = local.tm_gmtoff
         zone = local.tm_zone
     except AttributeError:
-        offset = datetime_.fromtimestamp(timestamp) - datetime_.utcfromtimestamp(timestamp)
+        # Workaround for Python 3.5.
+        utc_naive = datetime_.fromtimestamp(timestamp, tz=timezone.utc).replace(tzinfo=None)
+        offset = datetime_.fromtimestamp(timestamp) - utc_naive
         seconds = offset.total_seconds()
         zone = strftime("%Z")
 

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -85,7 +85,6 @@
 import builtins
 import contextlib
 import functools
-import itertools
 import logging
 import re
 import sys
@@ -182,7 +181,7 @@ class Core:
             name: (name, name, level.no, level.icon) for name, level in self.levels.items()
         }
 
-        self.handlers_count = itertools.count()
+        self.handlers_count = 0
         self.handlers = {}
 
         self.extra = {}
@@ -778,7 +777,8 @@ class Logger:
         >>> logger.add(stream_object, level="INFO")
         """
         with self._core.lock:
-            handler_id = next(self._core.handlers_count)
+            handler_id = self._core.handlers_count
+            self._core.handlers_count += 1
 
         error_interceptor = ErrorInterceptor(catch, handler_id)
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(
             # Type checking.
             "mypy==v0.910 ; python_version<'3.6'",
             "mypy==v0.971 ; python_version>='3.6' and python_version<'3.7'",
-            "mypy==v1.4.1 ; python_version>='3.7'",
+            "mypy==v1.4.1 ; python_version>='3.7' and python_version<'3.8'",
+            "mypy==v1.5.1 ; python_version>='3.8'",
             # Docs.
             "Sphinx==7.2.5 ; python_version>='3.9'",
             "sphinx-autobuild==2021.3.14 ; python_version>='3.9'",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/tests/exceptions/output/modern/f_string.txt
+++ b/tests/exceptions/output/modern/f_string.txt
@@ -1,11 +1,18 @@
 
 [33m[1mTraceback (most recent call last):[0m
 
-  File "[32mtests/exceptions/source/modern/[0m[32m[1mf_string.py[0m", line [33m17[0m, in [35m<module>[0m
+  File "[32mtests/exceptions/source/modern/[0m[32m[1mf_string.py[0m", line [33m21[0m, in [35m<module>[0m
     [1mhello[0m[1m([0m[1m)[0m
     [36m└ [0m[36m[1m<function hello at 0xDEADBEEF>[0m
 
-  File "[32mtests/exceptions/source/modern/[0m[32m[1mf_string.py[0m", line [33m13[0m, in [35mhello[0m
-    [36mf"{name}"[0m [35m[1mand[0m [36mf'{{ {f / 0} }}'[0m
+  File "[32mtests/exceptions/source/modern/[0m[32m[1mf_string.py[0m", line [33m11[0m, in [35mhello[0m
+    [1moutput[0m [35m[1m=[0m [36mf"[0m[36mHello[0m[36m"[0m [35m[1m+[0m [36mf'[0m[36m [0m[36m'[0m [35m[1m+[0m [36mf"""[0m[36mWorld[0m[36m"""[0m [35m[1mand[0m [1mworld[0m[1m([0m[1m)[0m
+    [36m                                            └ [0m[36m[1m<function world at 0xDEADBEEF>[0m
+
+  File "[32mtests/exceptions/source/modern/[0m[32m[1mf_string.py[0m", line [33m17[0m, in [35mworld[0m
+    [36mf"[0m[1m{[0m[1mname[0m[1m}[0m[36m -> [0m[1m{[0m [1mf[0m [1m}[0m[36m"[0m [35m[1mand[0m [1m{[0m[1m}[0m [35m[1mor[0m [36mf'[0m[36m{{[0m[36m [0m[1m{[0m[1mf[0m [35m[1m/[0m [34m[1m0[0m[1m}[0m[36m }}[0m[36m'[0m
+    [36m   │          │                    └ [0m[36m[1m1[0m
+    [36m   │          └ [0m[36m[1m1[0m
+    [36m   └ [0m[36m[1m'world'[0m
 
 [31m[1mZeroDivisionError[0m:[1m division by zero[0m

--- a/tests/exceptions/source/modern/f_string.py
+++ b/tests/exceptions/source/modern/f_string.py
@@ -8,9 +8,13 @@ logger.add(sys.stderr, format="", colorize=True, backtrace=False, diagnose=True)
 
 
 def hello():
+    output = f"Hello" + f' ' + f"""World""" and world()
+
+
+def world():
     name = "world"
     f = 1
-    f"{name}" and f'{{ {f / 0} }}'
+    f"{name} -> { f }" and {} or f'{{ {f / 0} }}'
 
 
 with logger.catch():

--- a/tests/test_exceptions_formatting.py
+++ b/tests/test_exceptions_formatting.py
@@ -230,7 +230,6 @@ def test_exception_others(filename):
     "filename, minimum_python_version",
     [
         ("type_hints", (3, 6)),
-        ("f_string", (3, 6)),
         ("positional_only_argument", (3, 8)),
         ("walrus_operator", (3, 8)),
         ("match_statement", (3, 10)),
@@ -242,6 +241,7 @@ def test_exception_others(filename):
         ("grouped_as_cause_and_context", (3, 11)),
         ("grouped_max_length", (3, 11)),
         ("grouped_max_depth", (3, 11)),
+        ("f_string", (3, 12)),  # Available since 3.6 but in 3.12 the lexer for f-string changed.
     ],
 )
 def test_exception_modern(filename, minimum_python_version):


### PR DESCRIPTION
- Fix failures of a few unit tests related to exception formatting.
- Fix warnings caused by usage of deprecated function in the codebase. 
- Fix some warnings appearing in tests.
  - There's still one warning lingering due to `dateutil` (which is a dependency of `freezegun`). It should go away when a new release is published.
  - There are still many warnings related to tests using `enqueue=True` with `fork()` (mixing fork and thread is deprecated). I currently do not have a solution for this.