### PR TITLE
Improve startuptime: don't import IPython/ipykernal if not in jupyter

### DIFF
--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -6,7 +6,7 @@ def should_colorize(stream):
     if stream is None:
         return False
 
-    if stream is sys.stdout or stream is sys.stderr:
+    if "IPython" in sys.modules and (stream is sys.stdout or stream is sys.stderr):
         try:
             import ipykernel
             import IPython

--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import sys
 
@@ -6,7 +7,7 @@ def should_colorize(stream):
     if stream is None:
         return False
 
-    if "IPython" in sys.modules and (stream is sys.stdout or stream is sys.stderr):
+    if getattr(builtins, "__IPYTHON__", False) and (stream is sys.stdout or stream is sys.stderr):
         try:
             import ipykernel
             import IPython

--- a/tests/test_colorama.py
+++ b/tests/test_colorama.py
@@ -179,6 +179,16 @@ def test_jupyter_fixed(monkeypatch, patched, out_class, expected):
     assert should_colorize(stream) is expected
 
 
+def test_jupyter_missing_lib(monkeypatch):
+    # Missing ipykernal so jupyter block will err, should handle gracefully
+    stream = StreamIsattyFalse()
+
+    monkeypatch.setitem(sys.modules, "IPython", MagicMock())
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    assert should_colorize(stream) is False
+
+
 @pytest.mark.parametrize("patched", ["__stdout__", "__stderr__"])
 @pytest.mark.skipif(os.name == "nt", reason="Colorama is required on Windows")
 def test_dont_wrap_on_linux(monkeypatch, patched, patch_colorama):

--- a/tests/test_colorama.py
+++ b/tests/test_colorama.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import sys
 from unittest.mock import MagicMock
@@ -172,6 +173,7 @@ def test_jupyter_fixed(monkeypatch, patched, out_class, expected):
     ipykernel.zmqshell.ZMQInteractiveShell = Shell
     ipykernel.iostream.OutStream = out_class
 
+    monkeypatch.setattr(builtins, "__IPYTHON__", True, raising=False)
     monkeypatch.setitem(sys.modules, "IPython", ipython)
     monkeypatch.setitem(sys.modules, "ipykernel", ipykernel)
     monkeypatch.setattr(sys, patched, stream, raising=False)
@@ -183,7 +185,7 @@ def test_jupyter_missing_lib(monkeypatch):
     # Missing ipykernal so jupyter block will err, should handle gracefully
     stream = StreamIsattyFalse()
 
-    monkeypatch.setitem(sys.modules, "IPython", MagicMock())
+    monkeypatch.setattr(builtins, "__IPYTHON__", True, raising=False)
     monkeypatch.setattr(sys, "stdout", stream)
 
     assert should_colorize(stream) is False


### PR DESCRIPTION
Importing `Ipython/ipykernal` when running from terminal slows startup a fair bit on my machine. 

If in jupyter `IPython` will already be imported, so can skip the imports directly when not needed. 

```bash
time python -c "import loguru"
```

Before:
```
0.31s user 0.06s system 99% cpu 0.374 total
0.22s user 0.02s system 99% cpu 0.242 total
0.20s user 0.03s system 99% cpu 0.237 total
0.21s user 0.03s system 99% cpu 0.242 total
0.22s user 0.03s system 99% cpu 0.245 total
```

After:
```
0.04s user 0.01s system 97% cpu 0.053 total
0.05s user 0.00s system 98% cpu 0.051 total
0.04s user 0.01s system 98% cpu 0.053 total
0.05s user 0.00s system 98% cpu 0.054 total
0.04s user 0.01s system 98% cpu 0.054 total
```

