### PR TITLE
Setup formatted exception to use with async pickling

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -8,6 +8,7 @@ from threading import Thread
 
 from ._colorizer import Colorizer
 from ._locks_machinery import create_handler_lock
+from ._recattrs import RecordException
 
 
 def prepare_colored_format(format_, ansi_level):
@@ -141,7 +142,7 @@ class Handler:
             if not record["exception"]:
                 formatter_record["exception"] = ""
             else:
-                type_, value, tb = record["exception"]
+                type_, value, tb, _ = record["exception"]
                 formatter = self._exception_formatter
                 lines = formatter.format_exception(type_, value, tb, from_decorator=from_decorator)
                 formatter_record["exception"] = "".join(lines)

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -88,6 +88,7 @@ import functools
 import logging
 import re
 import sys
+import traceback as traceback_module
 import warnings
 from collections import namedtuple
 from inspect import isclass, iscoroutinefunction, isgeneratorfunction
@@ -1975,7 +1976,7 @@ class Logger:
                 type_, value, traceback = exception
             else:
                 type_, value, traceback = sys.exc_info()
-            formatted_exception = "".join(traceback.format_exception(
+            formatted_exception = "".join(traceback_module.format_exception(
                 type_,
                 value,
                 traceback

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1975,7 +1975,12 @@ class Logger:
                 type_, value, traceback = exception
             else:
                 type_, value, traceback = sys.exc_info()
-            exception = RecordException(type_, value, traceback)
+            formatted_exception = "".join(traceback.format_exception(
+                type_,
+                value,
+                traceback
+            ))
+            exception = RecordException(type_, value, traceback, formatted_exception)
         else:
             exception = None
 

--- a/loguru/_recattrs.py
+++ b/loguru/_recattrs.py
@@ -59,9 +59,9 @@ class RecordProcess:
         return self.id.__format__(spec)
 
 
-class RecordException(namedtuple("RecordException", ("type", "value", "traceback"))):
+class RecordException(namedtuple("RecordException", ("type", "value", "traceback", "formatted_traceback"))):
     def __repr__(self):
-        return "(type=%r, value=%r, traceback=%r)" % (self.type, self.value, self.traceback)
+        return "(type=%r, value=%r, traceback=%r, formatted_traceback=%r)" % (self.type, self.value, self.traceback, self.formatted_traceback)
 
     def __reduce__(self):
         # The traceback is not picklable, therefore it needs to be removed. Additionally, there's a
@@ -71,20 +71,44 @@ class RecordException(namedtuple("RecordException", ("type", "value", "traceback
         # the pickled value later for optimization (so that it's not pickled twice). It's important
         # to note that custom exceptions might not necessarily raise a PickleError, hence the
         # generic Exception catch.
+        pickled_value_success = True
         try:
             pickled_value = pickle.dumps(self.value)
         except Exception:
-            return (RecordException, (self.type, None, None))
-        else:
-            return (RecordException._from_pickled_value, (self.type, pickled_value, None))
+            pickled_value_success = False
+
+        pickled_formatted_traceback_success = True
+        try:
+            pickled_formatted_traceback = pickle.dumps(self.formatted_traceback)
+        except Exception:
+            pickled_formatted_traceback_success = False
+
+        if pickled_value_success and pickled_formatted_traceback_success:
+            return (RecordException._from_pickled, (self.type, pickled_value, None, pickled_formatted_traceback))
+        elif pickled_value_success:
+            return (RecordException._from_pickled, (self.type, pickled_value, None, None))
+        elif pickled_formatted_traceback_success:
+            return (RecordException._from_pickled, (self.type, None, None, pickled_formatted_traceback))
+        return (RecordException, (self.type, None, None, None))
 
     @classmethod
-    def _from_pickled_value(cls, type_, pickled_value, traceback_):
-        try:
-            # It's safe to use "pickle.loads()" in this case because the pickled value is generated
-            # by the same code and is not coming from an untrusted source.
-            value = pickle.loads(pickled_value)
-        except Exception:
-            return cls(type_, None, traceback_)
-        else:
-            return cls(type_, value, traceback_)
+    def _from_pickled(cls, type_, pickled_value, traceback_, pickled_formatted_traceback_):
+        unpickled_value = None
+        if pickled_value:
+            try:
+                # It's safe to use "pickle.loads()" in this case because the pickled value is generated
+                # by the same code and is not coming from an untrusted source.
+                unpickled_value = pickle.loads(pickled_value)
+            except Exception:
+                pass
+
+        unpickled_formatted_traceback_ = None
+        if pickled_formatted_traceback_:
+            try:
+                # It's safe to use "pickle.loads()" in this case because the pickled value is generated
+                # by the same code and is not coming from an untrusted source.
+                unpickled_formatted_traceback_ = pickle.loads(pickled_formatted_traceback_)
+            except Exception:
+                pass
+
+        return cls(type_, unpickled_value, traceback_, unpickled_formatted_traceback_)

--- a/loguru/_recattrs.py
+++ b/loguru/_recattrs.py
@@ -100,7 +100,7 @@ class RecordException(namedtuple("RecordException", ("type", "value", "traceback
                 # by the same code and is not coming from an untrusted source.
                 unpickled_value = pickle.loads(pickled_value)
             except Exception:
-                pass
+                unpickled_value = None
 
         unpickled_formatted_traceback_ = None
         if pickled_formatted_traceback_:
@@ -109,6 +109,6 @@ class RecordException(namedtuple("RecordException", ("type", "value", "traceback
                 # by the same code and is not coming from an untrusted source.
                 unpickled_formatted_traceback_ = pickle.loads(pickled_formatted_traceback_)
             except Exception:
-                pass
+                unpickled_formatted_traceback_ = None
 
         return cls(type_, unpickled_value, traceback_, unpickled_formatted_traceback_)


### PR DESCRIPTION
Hi thank you for an awesome logging lib! It has made my life 1000% easier...

I am using `enqueue=True` and I ran into some pickling related issues when it came to 3rd party libraries and their exceptions. I still want to have a stacktrace, but ultimately unless we can pickle the exception, I can't get it downstream in the `sink`. Ultimately I added an extra field to the `RecordException` that formats the exception and saves it as string that can be safely pickled.

Overall I think this would solve some of the issues, however it isn't customizable.

I setup this initial PR as a work around to it. I didn't want to sink to much time into until you give some feedback to see if this would be even a good idea and something that would want to be adopted. Would love to clean this up after given some feedback. Please rip into it and let me know!