### PR TITLE
Linking to `logot` from docs

### DIFF
--- a/docs/resources/migration.rst
+++ b/docs/resources/migration.rst
@@ -278,6 +278,8 @@ The |captureWarnings| function which redirects alerts from the |warnings| module
     warnings.showwarning = showwarning
 
 
+.. _migration-assert-logs:
+
 Replacing ``assertLogs()`` method from ``unittest`` library
 -----------------------------------------------------------
 
@@ -316,6 +318,12 @@ It provides the list of :ref:`logged messages <message>` for each of which you c
             self.assertIn("Invalid value", message)
             self.assertEqual(message.record["level"].name, "ERROR")
 
+.. seealso::
+
+   See :ref:`testing logging <recipes-testing>` for more information.
+
+
+.. _migration-caplog:
 
 Replacing ``caplog`` fixture from ``pytest`` library
 ----------------------------------------------------
@@ -367,3 +375,7 @@ Note that if you want Loguru logs to be propagated to Pytest terminal reporter, 
         handler_id = logger.add(logging_plugin.report_handler, format="{message}")
         yield
         logger.remove(handler_id)
+
+.. seealso::
+
+   See :ref:`testing logging <recipes-testing>` for more information.

--- a/docs/resources/recipes.rst
+++ b/docs/resources/recipes.rst
@@ -43,6 +43,12 @@ Code snippets and recipes for ``loguru``
 .. |if-name-equals-main| replace:: ``if __name__ == "__main__":``
 .. _if-name-equals-main: https://docs.python.org/3/library/__main__.html#idiomatic-usage
 
+.. |logot| replace:: ``logot``
+.. _logot: https://logot.readthedocs.io/
+
+.. |pytest| replace:: ``pytest``
+.. _pytest: https://docs.pytest.org/en/latest/
+
 .. |stackprinter| replace:: ``stackprinter``
 .. _stackprinter: https://github.com/cknd/stackprinter
 
@@ -1043,3 +1049,36 @@ Another thing to keep in mind when dealing with multiprocessing is the fact that
         worker = workers_a.Worker()
         with context.Pool(4, initializer=worker.set_logger, initargs=(logger, )) as pool:
             results = pool.map(worker.work, [1, 10, 100])
+
+
+.. _recipes-testing:
+
+Testing logging
+---------------
+
+Logging calls can be tested using |logot|_, a high-level log testing library with built-in support for Loguru::
+
+    from logot import Logot, logged
+
+    def test_something(logot: Logot) -> None:
+        do_something()
+        logot.assert_logged(logged.info("Something was done"))
+
+Enable Loguru log capture in your |pytest|_ configuration:
+
+.. code:: toml
+
+   [tool.pytest.ini_options]
+   logot_capturer = "logot.loguru.LoguruCapturer"
+
+.. seealso::
+
+    See `using logot with Loguru <https://logot.readthedocs.io/latest/integrations/loguru.html>`_ for more information
+    about `configuring pytest <https://logot.readthedocs.io/latest/integrations/loguru.html#enabling-for-pytest>`_
+    and `configuring unittest <https://logot.readthedocs.io/latest/integrations/loguru.html#enabling-for-unittest>`_.
+
+.. note::
+
+    When migrating an existing project from standard :mod:`logging`, it can be useful to migrate your existing test
+    cases too. See :ref:`migrating assertLogs() <migration-assert-logs>` and :ref:`migrating caplog <migration-caplog>`
+    for more information.


### PR DESCRIPTION
I've added a new "Testing logging" section to the "Code snippets and recipes" doc. There didn't seem to be any particular order here, and placing it in an arbitrary place felt... _arbitrary_, while the top felt... _presumptuous_! I've linked to the existing migrations guides for existing projects with existing test cases.

I've also added a link _to_ "Testing logging" from the migrations guides. Hopefully that cross-links things nicely without blarting all over your docs.

Let me know if there's anything you'd like changed! 🙇 

See #1072