### PR TITLE
Modified Internal log level cache for better interoperability

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -178,9 +178,11 @@ class Core:
         # Cache used internally to quickly access level attributes based on their name or severity.
         # It can also contain integers as keys, it serves to avoid calling "isinstance()" repeatedly
         # when "logger.log()" is used.
-        self.levels_lookup = {
-            name: (name, name, level.no, level.icon) for name, level in self.levels.items()
-        }
+        self.levels_lookup = {}
+        for name, level in self.levels.items():
+            # Update the dictionary for both keys - the log level name and the log level severity number
+            self.levels_lookup[name] = (name, name, level.no, level.icon)
+            self.levels_lookup[level.no] = (name, name, level.no, level.icon)
 
         self.handlers_count = 0
         self.handlers = {}


### PR DESCRIPTION
In my work I've come accross situations, where a third-party package is using my Loguru logger to emit logs. I've noticed that many time these messages are formated (colored) differently from messages emited in my code. After a brief investigation it turned out the third-party package is calling the `log()` method like this:

```python
self.logger.log(logging.INFO, message)
```

The `logging.INFO` variable is an integer constant `20`. However, Loguru's `Logger._log()` method expects a string, such as `"INFO"`. Not finding the integer `20` in the internal `core.levels_lookup` cache results into a different formatting of the message:

<img width="999" alt="image" src="https://github.com/Delgan/loguru/assets/2571856/baac6083-dba6-41bb-8bfb-987bd33c631d">

(The first message is logged through the third-party package, while the second is logged natively in my code)


It is not possible to solve this using a custom log filter, because in Loguru the log level is resolved internally and the `LogRecord.levels` information is not used. 

I believe passing the log level using the logging package's enum is a good and wide-spread practice and should be supported by Loguru.

**I propose a simple solution:** adding integer keys in additon to string keys to the internal log level cache. This effectivelly resolves the issue, increasing Loguru's interoperability with other packages without any modifications the the internal processing flow and logic.
