### PR TITLE
ci: add pypi release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
 
     - run: pipx run build
 
+    - run: twine check --strict dist/*
+
     - run: pipx run twine upload dist/* --disable-progress-bar
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+
+    - run: pipx run build
+
+    - run: pipx run twine upload dist/* --disable-progress-bar
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
how to use this:

create a pypi api token at https://pypi.org/manage/account/ and set project secret at https://github.com/Delgan/loguru/settings/secrets/actions , with name `PYPI_API_TOKEN`. 

After it's done, change version and add a git tag, then push it to github.

