### PR TITLE
Fix for Runtime error when reinitializing logger

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -2033,7 +2033,7 @@ class Logger:
         for patcher in patchers:
             patcher(log_record)
 
-        # Create a copy to ensure safety when interating over handlers
+        # Create a copy to ensure safety when iterating over handlers
         for handler in list(core.handlers.values()):
             handler.emit(log_record, level_id, from_decorator, raw, colored_message)
 

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -2033,7 +2033,8 @@ class Logger:
         for patcher in patchers:
             patcher(log_record)
 
-        for handler in core.handlers.values():
+        # Create a copy to ensure safety when interating over handlers
+        for handler in list(core.handlers.values()):
             handler.emit(log_record, level_id, from_decorator, raw, colored_message)
 
     def trace(__self, __message, *args, **kwargs):  # noqa: N805


### PR DESCRIPTION
We hit this error intermittently as we have to reinitialize our logger at least once during our application startup.

File "/opt/pysetup/.venv/lib/python3.11/site-packages/loguru/_logger.py", line 2031, in _log
    for handler in core.handlers.values():
RuntimeError: dictionary changed size during iteration

Fix is to copy the values to avoid the "changed size" error.

Fixes: https://github.com/Delgan/loguru/issues/1183