### PR TITLE
Fix possible infinite recursion with "__repr__" and "logger.catch()"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@
 - Fix ``diagnose=True`` option of exception formatting not working as expected with Python 3.13 (`#1235 <https://github.com/Delgan/loguru/issues/1235>`_, thanks `@etianen <https://github.com/etianen>`_).
 - Fix non-standard level names not fully compatible with ``logging.Formatter()`` (`#1231 <https://github.com/Delgan/loguru/issues/1231>`_, thanks `@yechielb2000 <https://github.com/yechielb2000>`_).
 - Fix inability to display a literal ``"\"`` immediately before color markups (`#988 <https://github.com/Delgan/loguru/issues/988>`_).
+- Fix possible infinite recursion when an exception is raised from a ``__repr__``  method decorated with ``logger.catch()`` (`#1044 <https://github.com/Delgan/loguru/issues/1044>`_).
 - Improve performance of ``datetime`` formatting while logging messages (`#1201 <https://github.com/Delgan/loguru/issues/1201>`_, thanks `@trim21 <https://github.com/trim21>`_).
 - Reduce startup time in the presence of installed but unused ``IPython`` third-party library (`#1001 <https://github.com/Delgan/loguru/issues/1001>`_, thanks `@zakstucke <https://github.com/zakstucke>`_).
 

--- a/tests/exceptions/output/others/broken_but_decorated_repr.txt
+++ b/tests/exceptions/output/others/broken_but_decorated_repr.txt
@@ -1,0 +1,22 @@
+
+Traceback (most recent call last):
+
+> File "tests/exceptions/source/others/broken_but_decorated_repr.py", line 25, in <module>
+    repr(foo)
+         └ <unprintable Foo object>
+
+  File "tests/exceptions/source/others/broken_but_decorated_repr.py", line 12, in __repr__
+    raise ValueError("Something went wrong (Foo)")
+
+ValueError: Something went wrong (Foo)
+
+Traceback (most recent call last):
+
+  File "tests/exceptions/source/others/broken_but_decorated_repr.py", line 31, in <module>
+    repr(bar)
+         └ <unprintable Bar object>
+
+> File "tests/exceptions/source/others/broken_but_decorated_repr.py", line 18, in __repr__
+    raise ValueError("Something went wrong (Bar)")
+
+ValueError: Something went wrong (Bar)

--- a/tests/exceptions/source/others/broken_but_decorated_repr.py
+++ b/tests/exceptions/source/others/broken_but_decorated_repr.py
@@ -1,0 +1,33 @@
+import sys
+
+from loguru import logger
+
+logger.remove()
+logger.add(sys.stderr, format="", diagnose=True, backtrace=True, colorize=False, catch=True)
+
+
+class Foo:
+    @logger.catch(reraise=True)
+    def __repr__(self):
+        raise ValueError("Something went wrong (Foo)")
+
+
+class Bar:
+    def __repr__(self):
+        with logger.catch(reraise=True):
+            raise ValueError("Something went wrong (Bar)")
+
+
+foo = Foo()
+bar = Bar()
+
+try:
+    repr(foo)
+except ValueError:
+    pass
+
+
+try:
+    repr(bar)
+except ValueError:
+    pass

--- a/tests/test_exceptions_catch.py
+++ b/tests/test_exceptions_catch.py
@@ -2,6 +2,7 @@ import asyncio
 import site
 import sys
 import sysconfig
+import threading
 import types
 
 import pytest
@@ -452,3 +453,174 @@ def test_error_when_decorating_class_with_parentheses():
         @logger.catch()
         class Foo:
             pass
+
+
+def test_unprintable_but_decorated_repr(writer):
+
+    class Foo:
+        @logger.catch(reraise=True)
+        def __repr__(self):
+            raise ValueError("Something went wrong")
+
+    logger.add(writer, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Something went wrong$"):
+        repr(foo)
+
+    assert writer.read().endswith("ValueError: Something went wrong\n")
+
+
+def test_unprintable_but_decorated_repr_without_reraise(writer):
+    class Foo:
+        @logger.catch(reraise=False, default="?")
+        def __repr__(self):
+            raise ValueError("Something went wrong")
+
+    logger.add(writer, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+
+    foo = Foo()
+
+    repr(foo)
+
+    assert writer.read().endswith("ValueError: Something went wrong\n")
+
+
+def test_unprintable_but_decorated_multiple_sinks(capsys):
+    class Foo:
+        @logger.catch(reraise=True)
+        def __repr__(self):
+            raise ValueError("Something went wrong")
+
+    logger.add(sys.stderr, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+    logger.add(sys.stdout, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Something went wrong$"):
+        repr(foo)
+
+    out, err = capsys.readouterr()
+    assert out.endswith("ValueError: Something went wrong\n")
+    assert err.endswith("ValueError: Something went wrong\n")
+
+
+def test_unprintable_but_decorated_repr_with_enqueue(writer):
+    class Foo:
+        @logger.catch(reraise=True)
+        def __repr__(self):
+            raise ValueError("Something went wrong")
+
+    logger.add(
+        writer, backtrace=True, diagnose=True, colorize=False, format="", catch=False, enqueue=True
+    )
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Something went wrong$"):
+        repr(foo)
+
+    logger.complete()
+
+    assert writer.read().endswith("ValueError: Something went wrong\n")
+
+
+def test_unprintable_but_decorated_repr_twice(writer):
+    class Foo:
+        @logger.catch(reraise=True)
+        @logger.catch(reraise=True)
+        def __repr__(self):
+            raise ValueError("Something went wrong")
+
+    logger.add(writer, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Something went wrong$"):
+        repr(foo)
+
+    assert writer.read().endswith("ValueError: Something went wrong\n")
+
+
+def test_unprintable_with_catch_context_manager(writer):
+    class Foo:
+        def __repr__(self):
+            with logger.catch(reraise=True):
+                raise ValueError("Something went wrong")
+
+    logger.add(writer, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Something went wrong$"):
+        repr(foo)
+
+    assert writer.read().endswith("ValueError: Something went wrong\n")
+
+
+def test_unprintable_with_catch_context_manager_reused(writer):
+    def sink(_):
+        raise ValueError("Sink error")
+
+    logger.remove()
+    logger.add(sink, catch=False)
+
+    catcher = logger.catch(reraise=False)
+
+    class Foo:
+        def __repr__(self):
+            with catcher:
+                raise ValueError("Something went wrong")
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Sink error$"):
+        repr(foo)
+
+    logger.remove()
+    logger.add(writer)
+
+    with catcher:
+        raise ValueError("Error")
+
+    assert writer.read().endswith("ValueError: Error\n")
+
+
+def test_unprintable_but_decorated_repr_multiple_threads(writer):
+    wait_for_repr_block = threading.Event()
+    wait_for_worker_finish = threading.Event()
+
+    recursive = False
+
+    class Foo:
+        @logger.catch(reraise=True)
+        def __repr__(self):
+            nonlocal recursive
+            if not recursive:
+                recursive = True
+            else:
+                wait_for_repr_block.set()
+                wait_for_worker_finish.wait()
+            raise ValueError("Something went wrong")
+
+    def worker():
+        wait_for_repr_block.wait()
+        with logger.catch(reraise=False):
+            raise ValueError("Worker error")
+        wait_for_worker_finish.set()
+
+    logger.add(writer, backtrace=True, diagnose=True, colorize=False, format="", catch=False)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+
+    foo = Foo()
+
+    with pytest.raises(ValueError, match="^Something went wrong$"):
+        repr(foo)
+
+    thread.join()
+
+    assert "ValueError: Worker error\n" in writer.read()
+    assert writer.read().endswith("ValueError: Something went wrong\n")

--- a/tests/test_exceptions_formatting.py
+++ b/tests/test_exceptions_formatting.py
@@ -202,6 +202,7 @@ def test_exception_ownership(filename):
     "filename",
     [
         "assertionerror_without_traceback",
+        "broken_but_decorated_repr",
         "catch_as_context_manager",
         "catch_as_decorator_with_parentheses",
         "catch_as_decorator_without_parentheses",


### PR DESCRIPTION
Fix #1044.

We must not capture any exception with `logger.catch()` while already being handling an exception in `logger.catch()`.

The implementation is very similar to what @ismagilli proposed in #1066.
Main differences are that the `_already_logging_exception` flag is bound to the `logger` instead of the `Catcher` (so that it the recursion detection works with `logger.catch` used as context manager) and that we use `threading.local` (because others threads must not be affected).
Since exception formatting occurs sequentially in the thread capturing the error, it should be fine.

The following code:

```python
from loguru import logger


class Foo:
    @logger.catch(reraise=True)
    def __repr__(self):
        raise ValueError("Something went wrong")


if __name__ == "__main__":
    foo = Foo()
    try:
        repr(foo)
    except:
        pass
```

Now produces the following logs (instead of infinite recursion):

```
2024-11-23 12:01:20.484 | ERROR    | __main__:<module>:13 - An error has been caught in function '<module>', process 'MainProcess' (15759), thread 'MainThread' (138815718079360):
Traceback (most recent call last):

> File "/home/delgan/Code/loguru/test.py", line 13, in <module>
    repr(foo)
         └ <unprintable Foo object>

  File "/home/delgan/Code/loguru/test.py", line 7, in __repr__
    raise ValueError("Something went wrong")

ValueError: Something went wrong
```