### PR TITLE
Fix "ValueError" using Loguru with Cython (when missing stack frame)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 `Unreleased`_
 =============
 
+- Fix Cython incompatibility caused by the absence of underlying stack frames, which resulted in a ValueError during logging (`#88 <https://github.com/Delgan/loguru/issues/88>`_).
 - Fix possible ``RuntimeError`` when removing all handlers with ``logger.remove()`` due to thread-safety issue (`#1183 <https://github.com/Delgan/loguru/issues/1183>`_, thanks `@jeremyk <https://github.com/jeremyk>`_).
 - Fix ``diagnose=True`` option of exception formatting not working as expected with Python 3.13 (`#1235 <https://github.com/Delgan/loguru/issues/1235>`_, thanks `@etianen <https://github.com/etianen>`_).
 - Fix non-standard level names not fully compatible with ``logging.Formatter()`` (`#1231 <https://github.com/Delgan/loguru/issues/1231>`_, thanks `@yechielb2000 <https://github.com/yechielb2000>`_).

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1956,10 +1956,21 @@ class Logger:
 
         (exception, depth, record, lazy, colors, raw, capture, patchers, extra) = options
 
-        frame = get_frame(depth + 2)
+        try:
+            frame = get_frame(depth + 2)
+        except ValueError:
+            f_globals = {}
+            f_lineno = 0
+            co_name = "<unknown>"
+            co_filename = "<unknown>"
+        else:
+            f_globals = frame.f_globals
+            f_lineno = frame.f_lineno
+            co_name = frame.f_code.co_name
+            co_filename = frame.f_code.co_filename
 
         try:
-            name = frame.f_globals["__name__"]
+            name = f_globals["__name__"]
         except KeyError:
             name = None
 
@@ -1985,9 +1996,7 @@ class Logger:
 
         current_datetime = aware_now()
 
-        code = frame.f_code
-        file_path = code.co_filename
-        file_name = basename(file_path)
+        file_name = basename(co_filename)
         thread = current_thread()
         process = current_process()
         elapsed = current_datetime - start_time
@@ -2007,10 +2016,10 @@ class Logger:
             "elapsed": elapsed,
             "exception": exception,
             "extra": {**core.extra, **context.get(), **extra},
-            "file": RecordFile(file_name, file_path),
-            "function": code.co_name,
+            "file": RecordFile(file_name, co_filename),
+            "function": co_name,
             "level": RecordLevel(level_name, level_no, level_icon),
-            "line": frame.f_lineno,
+            "line": f_lineno,
             "message": str(message),
             "module": splitext(file_name)[0],
             "name": name,

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -107,7 +107,7 @@ def test_multiple_activations():
     assert n() == 0
 
 
-def test_log_before_enable_f_globals_name_absent(writer, f_globals_name_absent):
+def test_log_before_enable_incomplete_frame_context(writer, incomplete_frame_context):
     logger.add(writer, format="{message}")
     logger.disable(None)
     logger.debug("nope")
@@ -117,7 +117,7 @@ def test_log_before_enable_f_globals_name_absent(writer, f_globals_name_absent):
     assert result == "yes\n"
 
 
-def test_log_before_disable_f_globals_name_absent(writer, f_globals_name_absent):
+def test_log_before_disable_incomplete_frame_context(writer, incomplete_frame_context):
     logger.add(writer, format="{message}")
     logger.enable(None)
     logger.debug("yes")
@@ -127,7 +127,7 @@ def test_log_before_disable_f_globals_name_absent(writer, f_globals_name_absent)
     assert result == "yes\n"
 
 
-def test_f_globals_name_absent_with_others(writer, f_globals_name_absent):
+def test_incomplete_frame_context_with_others(writer, incomplete_frame_context):
     logger.add(writer, format="{message}")
     logger.info("1")
     logger.enable(None)

--- a/tests/test_add_option_filter.py
+++ b/tests/test_add_option_filter.py
@@ -68,7 +68,7 @@ def test_filtered_out(filter, writer):
         {None: "INFO", "": "WARNING"},
     ],
 )
-def test_filtered_in_f_globals_name_absent(writer, filter, f_globals_name_absent):
+def test_filtered_in_incomplete_frame_context(writer, filter, incomplete_frame_context):
     logger.add(writer, filter=filter, format="{message}", catch=False)
     logger.info("It's ok")
     assert writer.read() == "It's ok\n"
@@ -85,7 +85,7 @@ def test_filtered_in_f_globals_name_absent(writer, filter, f_globals_name_absent
         {None: 100, "tests": True},
     ],
 )
-def test_filtered_out_f_globals_name_absent(writer, filter, f_globals_name_absent):
+def test_filtered_out_incomplete_frame_context(writer, filter, incomplete_frame_context):
     logger.add(writer, filter=filter, format="{message}", catch=False)
     logger.info("It's not ok")
     assert writer.read() == ""

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -113,7 +113,7 @@ def test_log_formatting(writer, message, args, kwargs, expected, use_log_functio
     assert writer.read() == expected + "\n"
 
 
-def test_f_globals_name_absent(writer, f_globals_name_absent):
+def test_formatting_incomplete_frame_context(writer, incomplete_frame_context):
     logger.add(writer, format="{name} {message}", colorize=False)
     logger.info("Foobar")
     assert writer.read() == "None Foobar\n"

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -200,6 +200,13 @@ def test_depth(writer):
     assert writer.read() == "test_depth : Test 1\na : Test 2\ntest_depth : Test 3\n"
 
 
+def test_depth_with_unreachable_frame(writer):
+    logger.add(writer, format="{name} : {function} : {file} : {line} : {message}")
+    logger.opt(depth=1000).debug("Test")
+    logger.remove()
+    assert writer.read() == "None : <unknown> : <unknown> : 0 : Test\n"
+
+
 def test_capture(writer):
     logger.add(writer, format="{message} {extra}")
     logger.opt(capture=False).info("No {}", 123, no=False)


### PR DESCRIPTION
Fix #88, #680.

In Cython, calling `logger.info()` used to cause a `ValueError("call stack is not deep enough")` which happens because of Cython optimizations.

As a workaround, this PR wraps the call into a `try / except` clause and generate "dummy" information if the frame failed to be retrieve:
- module name -> `None`
- file name -> `"<unknown>"`
- function name -> `"<unknwon>"`
- line no -> `0`

Not ideal, but certainly better than if Loguru didn't work at all