### PR TITLE
Fix tzinfo utcoffset error

### DIFF
--- a/loguru/_datetime.py
+++ b/loguru/_datetime.py
@@ -36,8 +36,9 @@ def _default_datetime_formatter(dt):
     )
 
 
-def _format_timezone(tzinfo, *, sep):
-    offset = tzinfo.utcoffset(None).total_seconds()
+def _format_timezone(dt, *, sep):
+    tzinfo = dt.tzinfo or timezone.utc
+    offset = tzinfo.utcoffset(dt).total_seconds()
     sign = "+" if offset >= 0 else "-"
     (h, m), s = divmod(abs(offset // 60), 60), abs(offset) % 60
     z = "%s%02d%s%02d" % (sign, h, sep, m)
@@ -103,8 +104,8 @@ def _compile_format(spec):
         "SSSSS": ("%05d", lambda t, dt: dt.microsecond // 10),
         "SSSSSS": ("%06d", lambda t, dt: dt.microsecond),
         "A": ("%s", lambda t, dt: "AM" if t.tm_hour < 12 else "PM"),
-        "Z": ("%s", lambda t, dt: _format_timezone(dt.tzinfo or timezone.utc, sep=":")),
-        "ZZ": ("%s", lambda t, dt: _format_timezone(dt.tzinfo or timezone.utc, sep="")),
+        "Z": ("%s", lambda t, dt: _format_timezone(dt, sep=":")),
+        "ZZ": ("%s", lambda t, dt: _format_timezone(dt, sep="")),
         "zz": ("%s", lambda t, dt: (dt.tzinfo or timezone.utc).tzname(dt) or ""),
         "X": ("%d", lambda t, dt: dt.timestamp()),
         "x": ("%d", lambda t, dt: int(dt.timestamp() * 1000000 + dt.microsecond)),
@@ -135,7 +136,6 @@ def _compile_format(spec):
 
 
 class datetime(datetime_):  # noqa: N801
-
     def __format__(self, fmt):
         return _compile_format(fmt)(self)
 


### PR DESCRIPTION
Hey all, thank you for the wonderful library!

Since 0.7.3 I started running into tons of errors:
```
Traceback (most recent call last):
  File "xxx\loguru\_handler.py", line 184, in emit
    formatted = precomputed_format.format_map(formatter_record)
  File "xxx\loguru\_datetime.py", line 140, in __format__
    return _compile_format(fmt)(self)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "xxx\loguru\_datetime.py", line 23, in _loguru_datetime_formatter
    args = tuple(f(t, dt) for f in formatters)
  File "xxx\loguru\_datetime.py", line 23, in <genexpr>
    args = tuple(f(t, dt) for f in formatters)
                 ~^^^^^^^
  File "xxx\loguru\_datetime.py", line 106, in <lambda>
    "Z": ("%s", lambda t, dt: _format_timezone(dt.tzinfo or timezone.utc, sep=":")),
                              ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx\loguru\_datetime.py", line 40, in _format_timezone
    offset = tzinfo.utcoffset(None).total_seconds()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'total_seconds'
```

Like #856 is requesting, I'm "manually" adding a configurable timezone to my logging:
```
def tzconverter(record):
    record["time"] = record["time"].astimezone(tz=ZoneInfo("..."))

logger.configure(patcher=tzconverter)
```

The issue seems to be that the new `_format_timezone` calls `tzinfo.utcoffset` with `None`. And apparently `zoneinfo.ZoneInfo` objects return `None` for that input. I think the proper way to handle this would be to instead call `tzinfo.utcoffset` with the current time.

This PR implements that!