### PR TITLE
Package licence in built sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 description = "Python logging made (stupidly) simple"
 dynamic = ['version']
 keywords = ["loguru", "logging", "logger", "log"]
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 name = "loguru"
 readme = 'README.md'
 requires-python = ">=3.5,<4.0"


### PR DESCRIPTION
The LICENSE is not packaged with the current build setup (check out PyPI, or also the failures here: https://github.com/conda-forge/loguru-feedstock/pull/39). I'm not totally familiar with flit, but this seems to work (although I'm not sure what best practice is exactly).