### PR TITLE
Resolve order dependency between test cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime
 import io
 import logging
+import multiprocessing
 import os
 import pathlib
 import sys
@@ -358,3 +359,10 @@ def _simulate_no_frame_available(monkeypatch):
 def incomplete_frame_context(request, monkeypatch):
     """Simulate different scenarios where the stack frame is incomplete or entirely absent."""
     yield from request.param(monkeypatch)
+
+
+@pytest.fixture(autouse=True)
+def reset_multiprocessing_start_method():
+    multiprocessing.set_start_method(None, force=True)
+    yield
+    multiprocessing.set_start_method(None, force=True)

--- a/tests/test_add_option_context.py
+++ b/tests/test_add_option_context.py
@@ -15,7 +15,6 @@ def reset_start_method():
 
 
 @pytest.mark.usefixtures("reset_start_method")
-@pytest.mark.usefixtures("reset_start_method")
 def test_using_multiprocessing_directly_if_context_is_none():
     logger.add(lambda _: None, enqueue=True, context=None)
     assert multiprocessing.get_start_method(allow_none=True) is not None

--- a/tests/test_add_option_context.py
+++ b/tests/test_add_option_context.py
@@ -7,13 +7,6 @@ import pytest
 from loguru import logger
 
 
-@pytest.fixture(autouse=True)
-def reset_start_method():
-    multiprocessing.set_start_method(None, force=True)
-    yield
-    multiprocessing.set_start_method(None, force=True)
-
-
 def test_using_multiprocessing_directly_if_context_is_none():
     logger.add(lambda _: None, enqueue=True, context=None)
     assert multiprocessing.get_start_method(allow_none=True) is not None

--- a/tests/test_add_option_context.py
+++ b/tests/test_add_option_context.py
@@ -9,16 +9,19 @@ from loguru import logger
 
 @pytest.fixture
 def reset_start_method():
+    multiprocessing.set_start_method(None, force=True)
     yield
     multiprocessing.set_start_method(None, force=True)
 
 
+@pytest.mark.usefixtures("reset_start_method")
 @pytest.mark.usefixtures("reset_start_method")
 def test_using_multiprocessing_directly_if_context_is_none():
     logger.add(lambda _: None, enqueue=True, context=None)
     assert multiprocessing.get_start_method(allow_none=True) is not None
 
 
+@pytest.mark.usefixtures("reset_start_method")
 @pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
 @pytest.mark.parametrize("context_name", ["fork", "forkserver"])
 def test_fork_context_as_string(context_name):
@@ -29,6 +32,7 @@ def test_fork_context_as_string(context_name):
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
+@pytest.mark.usefixtures("reset_start_method")
 def test_spawn_context_as_string():
     context = multiprocessing.get_context("spawn")
     with patch.object(type(context), "Lock", wraps=context.Lock) as mock:
@@ -37,6 +41,7 @@ def test_spawn_context_as_string():
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
+@pytest.mark.usefixtures("reset_start_method")
 @pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
 @pytest.mark.parametrize("context_name", ["fork", "forkserver"])
 def test_fork_context_as_object(context_name):
@@ -47,6 +52,7 @@ def test_fork_context_as_object(context_name):
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
+@pytest.mark.usefixtures("reset_start_method")
 def test_spawn_context_as_object():
     context = multiprocessing.get_context("spawn")
     with patch.object(type(context), "Lock", wraps=context.Lock) as mock:
@@ -55,6 +61,7 @@ def test_spawn_context_as_object():
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
+@pytest.mark.usefixtures("reset_start_method")
 def test_global_start_method_is_none_if_enqueue_is_false():
     logger.add(lambda _: None, enqueue=False, context=None)
     assert multiprocessing.get_start_method(allow_none=True) is None

--- a/tests/test_add_option_context.py
+++ b/tests/test_add_option_context.py
@@ -7,20 +7,18 @@ import pytest
 from loguru import logger
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def reset_start_method():
     multiprocessing.set_start_method(None, force=True)
     yield
     multiprocessing.set_start_method(None, force=True)
 
 
-@pytest.mark.usefixtures("reset_start_method")
 def test_using_multiprocessing_directly_if_context_is_none():
     logger.add(lambda _: None, enqueue=True, context=None)
     assert multiprocessing.get_start_method(allow_none=True) is not None
 
 
-@pytest.mark.usefixtures("reset_start_method")
 @pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
 @pytest.mark.parametrize("context_name", ["fork", "forkserver"])
 def test_fork_context_as_string(context_name):
@@ -31,7 +29,6 @@ def test_fork_context_as_string(context_name):
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
-@pytest.mark.usefixtures("reset_start_method")
 def test_spawn_context_as_string():
     context = multiprocessing.get_context("spawn")
     with patch.object(type(context), "Lock", wraps=context.Lock) as mock:
@@ -40,7 +37,6 @@ def test_spawn_context_as_string():
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
-@pytest.mark.usefixtures("reset_start_method")
 @pytest.mark.skipif(os.name == "nt", reason="Windows does not support forking")
 @pytest.mark.parametrize("context_name", ["fork", "forkserver"])
 def test_fork_context_as_object(context_name):
@@ -51,7 +47,6 @@ def test_fork_context_as_object(context_name):
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
-@pytest.mark.usefixtures("reset_start_method")
 def test_spawn_context_as_object():
     context = multiprocessing.get_context("spawn")
     with patch.object(type(context), "Lock", wraps=context.Lock) as mock:
@@ -60,7 +55,6 @@ def test_spawn_context_as_object():
     assert multiprocessing.get_start_method(allow_none=True) is None
 
 
-@pytest.mark.usefixtures("reset_start_method")
 def test_global_start_method_is_none_if_enqueue_is_false():
     logger.add(lambda _: None, enqueue=False, context=None)
     assert multiprocessing.get_start_method(allow_none=True) is None

--- a/tests/test_coroutine_sink.py
+++ b/tests/test_coroutine_sink.py
@@ -12,14 +12,6 @@ from loguru import logger
 from .conftest import new_event_loop_context, set_event_loop_context
 
 
-# Tests that invoke logger.add with enqueue=True set the multiprocessing start method
-# This ficture resets it to prevent flaky behaviour in other classes
-@pytest.fixture
-def reset_multiprocessing_start_method():
-    yield
-    multiprocessing.set_start_method(None, force=True)
-
-
 async def async_writer(msg):
     await asyncio.sleep(0.01)
     print(msg, end="")
@@ -424,7 +416,6 @@ def test_exception_in_coroutine_during_complete_not_caught(capsys, caplog):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5, 3), reason="Coroutine can't access running loop")
-@pytest.mark.usefixtures("reset_multiprocessing_start_method")
 def test_enqueue_coroutine_loop(capsys):
     with new_event_loop_context() as loop:
         logger.add(async_writer, enqueue=True, loop=loop, format="{message}", catch=False)
@@ -440,7 +431,6 @@ def test_enqueue_coroutine_loop(capsys):
     assert err == ""
 
 
-@pytest.mark.usefixtures("reset_multiprocessing_start_method")
 def test_enqueue_coroutine_from_inside_coroutine_without_loop(capsys):
     with new_event_loop_context() as loop:
 
@@ -653,7 +643,6 @@ class Writer:
         self.output += message
 
 
-@pytest.mark.usefixtures("reset_multiprocessing_start_method")
 def test_complete_with_sub_processes(capsys):
     spawn_context = multiprocessing.get_context("spawn")
 
@@ -676,7 +665,6 @@ def test_complete_with_sub_processes(capsys):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5, 3), reason="Coroutine can't access running loop")
-@pytest.mark.usefixtures("reset_multiprocessing_start_method")
 def test_invalid_coroutine_sink_if_no_loop_with_enqueue():
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Some of the test cases in tests/test_coroutine_sink.py set the spawn methods for the multiprocessing module, but do not reset it afterwards. This causes some tests in the tests/test_add_option_context.py class to fail, as they assume the spawn method to be "None" beforehand.

For example, the following will fail under Linux: 
```pytest tests/test_coroutine_sink.py::test_enqueue_coroutine_from_inside_coroutine_without_loop tests/test_add_option_context.py::test_fork_context_as_object[fork]```.

To address this, I have added a fixture to the polluting test cases in tests/test_coroutine_sink.py that resets the start method after they've been executed. Additionally, I've modified a pre-existing fixture in tests/test_add_option_context.py that resets the start method both before and after the tests that check for it (or potentially modify it) are executed.