### PR TITLE
Make make_logging_logger() return log level to original state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,7 +315,7 @@ def freeze_time(monkeypatch):
 
 @contextlib.contextmanager
 def make_logging_logger(name, handler, fmt="%(message)s", level="DEBUG"):
-    original_logging_level: int = logging.getLogger().getEffectiveLevel()
+    original_logging_level = logging.getLogger().getEffectiveLevel()
     logging_logger = logging.getLogger(name)
     logging_logger.setLevel(level)
     formatter = logging.Formatter(fmt)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,6 +315,7 @@ def freeze_time(monkeypatch):
 
 @contextlib.contextmanager
 def make_logging_logger(name, handler, fmt="%(message)s", level="DEBUG"):
+    original_logging_level: int = logging.getLogger().getEffectiveLevel()
     logging_logger = logging.getLogger(name)
     logging_logger.setLevel(level)
     formatter = logging.Formatter(fmt)
@@ -326,6 +327,7 @@ def make_logging_logger(name, handler, fmt="%(message)s", level="DEBUG"):
     try:
         yield logging_logger
     finally:
+        logging_logger.setLevel(original_logging_level)
         logging_logger.removeHandler(handler)
 
 


### PR DESCRIPTION
When tests use the `make_logging_logger()` context with the name set to None, the log level of the default/root logger is set but not reset after the context is terminated. This causes some tests in tests/test_coroutine_sink.py that make calls to the logger in an asynchronous context fail if they are executed after. This is caused by asyncio adding a log (specifically `Using selector: EpollSelector`)  at `DEBUG` level when initialized, and due to the modified debug level this message is not discarded as expected.

For example, the following execution would fail: `pytest tests/test_interception.py tests/test_coroutine_sink.py`.

I fixed this by making `make_logging_logger()` remember the original log level, and restore it before exiting.