### PR TITLE
Add requirement for TERM not to be dumb to enable colorization

### DIFF
--- a/loguru/_colorama.py
+++ b/loguru/_colorama.py
@@ -33,7 +33,7 @@ def should_colorize(stream):
             return True
 
     try:
-        return stream.isatty()
+        return stream.isatty() and os.environ.get('TERM', '') not in ('dumb', )
     except Exception:
         return False
 


### PR DESCRIPTION
Hello!

This is a trivial change to disable coloring in case the terminal is dumb. Personally, I encountered the problem in Emacs terminal/compilation buffers - the coloring symbols are just printed as is (i.e. ASCII).

Technically, some more comprehensive logic can be implemented to derive color support from the TERM variable - but I'm not sure it's actually warranted. `toe /usr/share/terminfo` on my Ubuntu instance returns about 40 different terminal types - for some, it's clear whether the color is supported or not, for others - not that clear. 

Anyway, just opting out in case of `dumb` terminal seems like a sensible thing to do (and it solves my problem in Emacs).

Please, let me know what you think.