### PR TITLE
Visualization of loguru's codebase

### DIFF
--- a/.codeboarding/Exception_Formatting_Utilities.md
+++ b/.codeboarding/Exception_Formatting_Utilities.md
@@ -1,0 +1,107 @@
+```mermaid
+
+graph LR
+
+    SyntaxHighlighter["SyntaxHighlighter"]
+
+    ExceptionFormatter["ExceptionFormatter"]
+
+    AnsiParser["AnsiParser"]
+
+    Colorizer["Colorizer"]
+
+    ExceptionFormatter -- "uses" --> SyntaxHighlighter
+
+    Colorizer -- "uses" --> AnsiParser
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component is dedicated to enhancing the visual presentation and debuggability of log messages within the `loguru` project. It achieves this by processing and rendering Python exception tracebacks in a more user-friendly and informative manner, including extracting detailed frame information, highlighting relevant code lines, and displaying variable values. Additionally, it manages the application and parsing of ANSI escape codes for colored terminal output, ensuring messages are visually distinct and readable.
+
+
+
+### SyntaxHighlighter
+
+This component is responsible for applying syntax highlighting to source code. It tokenizes Python code and formats different elements (keywords, strings, numbers, comments, etc.) with specific ANSI escape codes to enhance readability, particularly when displaying code snippets within exception tracebacks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `SyntaxHighlighter` (0:0)
+
+
+
+
+
+### ExceptionFormatter
+
+This is the core component for generating human-readable and detailed exception tracebacks. It integrates syntax highlighting (via `SyntaxHighlighter`), extracts and displays relevant variable values at the point of error, and provides improved formatting for complex scenarios like chained exceptions and exception groups, significantly aiding in debugging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ExceptionFormatter` (0:0)
+
+
+
+
+
+### AnsiParser
+
+This component is dedicated to parsing and converting Loguru's custom `<tag>`-based color markup within text into standard ANSI escape codes. It provides methods to either apply these colors to tokens or strip them entirely, enabling flexible control over terminal output styling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `AnsiParser` (0:0)
+
+
+
+
+
+### Colorizer
+
+This component acts as a high-level utility for applying and managing colors in log messages and format strings. It leverages the `AnsiParser` to process color tags, ensuring that log output is consistently and correctly styled for terminal display, thereby improving readability and visual organization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Colorizer` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Handler_Dispatcher.md
+++ b/.codeboarding/Handler_Dispatcher.md
@@ -1,0 +1,219 @@
+```mermaid
+
+graph LR
+
+    Handler["Handler"]
+
+    Sink_Implementations["Sink Implementations"]
+
+    Formatter["Formatter"]
+
+    Filter["Filter"]
+
+    Colorizer["Colorizer"]
+
+    ExceptionFormatter["ExceptionFormatter"]
+
+    Message["Message"]
+
+    ErrorInterceptor["ErrorInterceptor"]
+
+    Queueing_Mechanism["Queueing Mechanism"]
+
+    Handler -- "uses" --> Sink_Implementations
+
+    Handler -- "uses" --> Formatter
+
+    Handler -- "uses" --> Filter
+
+    Handler -- "uses" --> Colorizer
+
+    Handler -- "uses" --> ExceptionFormatter
+
+    Handler -- "creates" --> Message
+
+    Handler -- "uses" --> ErrorInterceptor
+
+    Handler -- "uses" --> Queueing_Mechanism
+
+    click Handler href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Handler.md" "Details"
+
+    click Sink_Implementations href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Sink_Implementations.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+These components are fundamental to the `Handler & Dispatcher` subsystem because they collectively enable the core functionality of Loguru: -   **`Handler`**: This is the orchestrator. Without it, log records would have no central point for processing, filtering, formatting, and dispatching. It's the brain of this subsystem.
+
+
+
+### Handler
+
+The `Handler` class is the central processing unit within Loguru's logging pipeline. It receives raw log records, applies filtering based on severity and custom rules, formats the log message (including dynamic formatting and colorization), and manages an optional multiprocessing-safe queue for non-blocking I/O. Finally, it dispatches the fully processed log messages to their designated `Sink Implementations`. It also integrates with an `ExceptionFormatter` for enhanced traceback presentation and an `ErrorInterceptor` for robust error handling during the logging process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Handler` (1:1)
+
+
+
+
+
+### Sink Implementations
+
+These are the concrete destinations where processed log messages are written. `Sink Implementations` can represent various output targets such as files, the console, or network streams. The `Handler` interacts with these sinks to perform the actual output operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Sink Implementations` (1:1)
+
+- `Sink Implementations` (1:1)
+
+
+
+
+
+### Formatter
+
+The `Formatter` is responsible for transforming raw log record data into a structured and human-readable string. It defines the layout and content of the final log message, which can include timestamps, log levels, message content, and other contextual information. The `Handler` utilizes a `Formatter` to prepare the log entry before dispatch.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Filter
+
+The `Filter` component provides a mechanism to selectively process log records. It evaluates incoming records against defined criteria (e.g., log level, custom conditions) and determines whether a record should be allowed to proceed through the logging pipeline or be discarded. The `Handler` applies this filter before formatting and dispatching.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Filter` (1:1)
+
+
+
+
+
+### Colorizer
+
+The `Colorizer` is dedicated to enhancing log output with ANSI escape codes, enabling colored text in terminal environments. It processes format strings and log messages to apply appropriate color and style, improving readability and visual distinction of log entries. The `Handler` leverages the `Colorizer` when colored output is enabled.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Colorizer` (1:1)
+
+
+
+
+
+### ExceptionFormatter
+
+This component specializes in formatting Python exceptions and tracebacks. It enriches standard traceback information with features like syntax highlighting, variable inspection, and improved presentation for chained exceptions, making debugging more efficient. The `Handler` uses the `ExceptionFormatter` to process exception details within log records.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ExceptionFormatter` (1:1)
+
+
+
+
+
+### Message
+
+`Message` is a simple string subclass used by the `Handler` to encapsulate the final formatted log string. It allows the `Handler` to attach the original log `record` object to the formatted message, providing a convenient way to access the raw log data even after formatting.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Message` (1:1)
+
+
+
+
+
+### ErrorInterceptor
+
+The `ErrorInterceptor` is a robust mechanism for handling exceptions that occur internally within the logging process, particularly within `Handler` operations or `Sink Implementations`. It prevents these internal errors from crashing the application and can optionally print error details to a fallback destination.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ErrorInterceptor` (1:1)
+
+
+
+
+
+### Queueing Mechanism
+
+This component provides an asynchronous and multiprocessing-safe queue for handling log messages. When enabled, the `Handler` places formatted log messages into this queue, allowing the actual writing to `Sink Implementations` to occur in a separate thread or process, thereby preventing blocking I/O operations from impacting the main application's performance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Queueing Mechanism` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Log_Record_Configuration_Utilities.md
+++ b/.codeboarding/Log_Record_Configuration_Utilities.md
@@ -1,0 +1,137 @@
+```mermaid
+
+graph LR
+
+    LogRecordAttributeDefinitions["LogRecordAttributeDefinitions"]
+
+    DateTimeFormattingAndUtilities["DateTimeFormattingAndUtilities"]
+
+    ConfigurationStringParsers["ConfigurationStringParsers"]
+
+    LogMessageFilteringLogic["LogMessageFilteringLogic"]
+
+    SystemDefaultConfiguration["SystemDefaultConfiguration"]
+
+    LogRecordAttributeDefinitions -- "Defines Structure For" --> LogMessageFilteringLogic
+
+    SystemDefaultConfiguration -- "Influences" --> LogMessageFilteringLogic
+
+    SystemDefaultConfiguration -- "Influences" --> DateTimeFormattingAndUtilities
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### LogRecordAttributeDefinitions
+
+This component defines the foundational data structures (classes like `RecordLevel`, `RecordFile`, `RecordThread`, `RecordProcess`, and `RecordException`) that encapsulate various attributes of a log message. These structures are crucial for building the comprehensive dictionary (`record`) that accompanies each log entry, providing a standardized way to store contextual information such as log level, file origin, process/thread details, and exception information. The `RecordException` class specifically handles the serialization and deserialization of exception details, ensuring robust error logging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L4-L16" target="_blank" rel="noopener noreferrer">`loguru._recattrs.RecordLevel` (4:16)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L19-L30" target="_blank" rel="noopener noreferrer">`loguru._recattrs.RecordFile` (19:30)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L33-L44" target="_blank" rel="noopener noreferrer">`loguru._recattrs.RecordThread` (33:44)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L47-L58" target="_blank" rel="noopener noreferrer">`loguru._recattrs.RecordProcess` (47:58)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L61-L91" target="_blank" rel="noopener noreferrer">`loguru._recattrs.RecordException` (61:91)</a>
+
+
+
+
+
+### DateTimeFormattingAndUtilities
+
+This component provides a comprehensive suite of utilities for handling and formatting `datetime` objects. Its functionalities include parsing various datetime format strings, managing timezone information (especially converting to UTC), and generating timezone-aware current timestamps. It ensures that all time-related information included in log records is accurate, consistently formatted, and easily manipulable for display or analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_datetime.py#L1-L2" target="_blank" rel="noopener noreferrer">`loguru._datetime` (1:2)</a>
+
+
+
+
+
+### ConfigurationStringParsers
+
+This component offers a collection of helper functions designed to parse human-readable string inputs into structured data types. Specifically, it handles parsing strings for durations (e.g., "1 week"), file sizes (e.g., "10 MB"), and rotation frequencies (e.g., "daily"). These parsing capabilities are essential for enabling flexible and intuitive configuration of log file management policies, such as rotation and retention.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_string_parsers.py#L1-L2" target="_blank" rel="noopener noreferrer">`loguru._string_parsers` (1:2)</a>
+
+
+
+
+
+### LogMessageFilteringLogic
+
+This component implements various strategies for filtering log messages based on predefined or custom criteria. It determines whether a given log message should be processed and emitted or discarded, offering fine-grained control over log verbosity and relevance. Filtering can be based on factors such as log level, module name, or the presence of a specific logger name.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_filters.py#L1-L2" target="_blank" rel="noopener noreferrer">`loguru._filters` (1:2)</a>
+
+
+
+
+
+### SystemDefaultConfiguration
+
+This component establishes and provides the default configuration settings for the entire logging system. It includes an `env` helper function to read environment variables, allowing these defaults to be overridden externally. This ensures a consistent and predictable baseline for logging behavior when no explicit configuration is provided by the user, covering aspects like default log levels, message formats, and other operational parameters.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_defaults.py#L3-L26" target="_blank" rel="noopener noreferrer">`loguru._defaults.env` (3:26)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Logger_Core.md
+++ b/.codeboarding/Logger_Core.md
@@ -1,0 +1,249 @@
+```mermaid
+
+graph LR
+
+    Logger_Core["Logger Core"]
+
+    User_Facing_Logger_API["User-Facing Logger API"]
+
+    Handler_Management["Handler Management"]
+
+    FileSink["FileSink"]
+
+    Locks_Machinery["Locks Machinery"]
+
+    Record_Attributes["Record Attributes"]
+
+    Colorizer["Colorizer"]
+
+    Context_Variables["Context Variables"]
+
+    Error_Interceptor["Error Interceptor"]
+
+    Simple_Sinks["Simple Sinks"]
+
+    Logger_Core -- "manages" --> Handler_Management
+
+    Logger_Core -- "utilizes" --> Locks_Machinery
+
+    User_Facing_Logger_API -- "delegates to" --> Logger_Core
+
+    User_Facing_Logger_API -- "uses" --> Record_Attributes
+
+    Handler_Management -- "registers" --> FileSink
+
+    Handler_Management -- "registers" --> Simple_Sinks
+
+    Locks_Machinery -- "protects" --> Logger_Core
+
+    Record_Attributes -- "provides data to" --> User_Facing_Logger_API
+
+    Colorizer -- "formats output for" --> Simple_Sinks
+
+    Context_Variables -- "enriches" --> Record_Attributes
+
+    Error_Interceptor -- "monitors" --> Handler_Management
+
+    Simple_Sinks -- "receives data from" --> Handler_Management
+
+    click Logger_Core href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Logger_Core.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Logger Core` (represented by the `loguru._logger.Core` class) is the foundational internal component that manages the entire logging system's state and operations. It's responsible for: Level Management, Handler Management, Global Configuration, Thread Safety, and Internal State.
+
+
+
+### Logger Core
+
+The central internal class (`loguru._logger.Core`) that orchestrates logging levels, handler management, global configuration, and thread safety. It's the backbone of the Loguru system, managing the internal state and logic for all logging operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_logger.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._logger.Core` (1:1)</a>
+
+
+
+
+
+### User-Facing Logger API
+
+This is the public `logger` object (an instance of `loguru._logger.Logger`) that users interact with directly to emit log messages (e.g., `logger.info()`, `logger.debug()`) and configure global logging behavior (e.g., `logger.add()`, `logger.remove()`). It acts as a facade, delegating core operations to the `Logger Core` instance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_logger.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._logger.Logger` (1:1)</a>
+
+
+
+
+
+### Handler Management
+
+This component (primarily within `loguru._handler.py` and managed by `Logger Core`) is responsible for the lifecycle and dispatching of log sinks (handlers). It manages adding, removing, and processing log messages through registered sinks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_handler.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._handler` (1:1)</a>
+
+
+
+
+
+### FileSink
+
+A specialized log sink (`loguru._file_sink.FileSink`) responsible for writing log messages to files, including advanced features like file rotation, retention, and compression. It's a concrete implementation of a handler managed by the `Logger Core` through `Handler Management`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_file_sink.py#L163-L441" target="_blank" rel="noopener noreferrer">`loguru._file_sink.FileSink` (163:441)</a>
+
+
+
+
+
+### Locks Machinery
+
+Provides the necessary synchronization primitives (locks) to ensure thread safety across the logging system, especially when multiple threads attempt to write logs or modify logging configurations concurrently.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_locks_machinery.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._locks_machinery` (1:1)</a>
+
+
+
+
+
+### Record Attributes
+
+This component is responsible for collecting and managing various attributes associated with a log message, such as the timestamp, level, message content, file path, line number, and extra context. These attributes form the "record" that is passed to sinks for formatting and output.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._recattrs` (1:1)</a>
+
+
+
+
+
+### Colorizer
+
+Handles the application of ANSI escape codes for coloring log messages, enabling visually distinct output in terminals. It's typically used by sinks that output to consoles.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_colorizer.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._colorizer` (1:1)</a>
+
+
+
+
+
+### Context Variables
+
+Provides mechanisms for managing context-specific data that can be implicitly added to log records, allowing for contextual logging without explicitly passing data through function calls.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_contextvars.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._contextvars` (1:1)</a>
+
+
+
+
+
+### Error Interceptor
+
+A mechanism to intercept and handle errors that occur within the logging process itself, preventing logging failures from crashing the application and potentially logging these internal errors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_error_interceptor.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._error_interceptor` (1:1)</a>
+
+
+
+
+
+### Simple Sinks
+
+Provides basic implementations of log sinks, such as writing to standard output (stdout) or standard error (stderr), without the advanced features of `FileSink`. These are often the default sinks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_simple_sinks.py#L1-L1" target="_blank" rel="noopener noreferrer">`loguru._simple_sinks` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Sink_Implementations.md
+++ b/.codeboarding/Sink_Implementations.md
@@ -1,0 +1,87 @@
+```mermaid
+
+graph LR
+
+    File_Sink["File Sink"]
+
+    Stream_Callable_Sinks["Stream & Callable Sinks"]
+
+    File_Sink -- "uses" --> loguru__ctime_functions
+
+    File_Sink -- "uses" --> loguru__datetime
+
+    Stream_Callable_Sinks -- "uses" --> loguru__asyncio_loop
+
+    loguru__logger -- "interacts with" --> File_Sink
+
+    loguru__logger -- "interacts with" --> Stream_Callable_Sinks
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component, `Sink Implementations`, serves as the collection of concrete destinations for Loguru's log output. It is fundamental to Loguru's operation as it defines *where* and *how* log messages are ultimately written. Without these implementations, the logger would have no output mechanism.
+
+
+
+### File Sink
+
+This component is responsible for writing log messages to files, offering advanced features such as automatic file rotation based on size or time, retention policies to manage the number or age of archived logs, and compression of old log files. It ensures robust and manageable log file handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `FileSink` (0:0)
+
+- `Rotation` (0:0)
+
+- `Retention` (0:0)
+
+- `Compression` (0:0)
+
+- `FileDateFormatter` (0:0)
+
+
+
+
+
+### Stream & Callable Sinks
+
+This component provides flexible and straightforward log output destinations. It includes `StreamSink` for writing to standard I/O streams (like `sys.stdout` or `sys.stderr`), `CallableSink` for directing log messages to any custom Python function, `StandardSink` for adapting Loguru records to be compatible with Python's built-in `logging` module handlers, and `AsyncSink` for handling asynchronous callable functions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `StreamSink` (0:0)
+
+- `CallableSink` (0:0)
+
+- `StandardSink` (0:0)
+
+- `AsyncSink` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,169 @@
+```mermaid
+
+graph LR
+
+    Logger_Core["Logger Core"]
+
+    Handler_Dispatcher["Handler & Dispatcher"]
+
+    Sink_Implementations["Sink Implementations"]
+
+    Exception_Formatting_Utilities["Exception & Formatting Utilities"]
+
+    Log_Record_Configuration_Utilities["Log Record & Configuration Utilities"]
+
+    Logger_Core -- "Dispatches log messages to" --> Handler_Dispatcher
+
+    Logger_Core -- "Utilizes" --> Log_Record_Configuration_Utilities
+
+    Handler_Dispatcher -- "Receives log records from" --> Logger_Core
+
+    Handler_Dispatcher -- "Dispatches processed messages to" --> Sink_Implementations
+
+    Handler_Dispatcher -- "Utilizes" --> Exception_Formatting_Utilities
+
+    Sink_Implementations -- "Receives processed log messages from" --> Handler_Dispatcher
+
+    Sink_Implementations -- "Relies on" --> Log_Record_Configuration_Utilities
+
+    Exception_Formatting_Utilities -- "Used by" --> Handler_Dispatcher
+
+    Exception_Formatting_Utilities -- "Receives raw exception data from" --> Log_Record_Configuration_Utilities
+
+    Log_Record_Configuration_Utilities -- "Provides log record data to" --> Logger_Core
+
+    Log_Record_Configuration_Utilities -- "Provides log record data to" --> Handler_Dispatcher
+
+    Log_Record_Configuration_Utilities -- "Supports" --> Sink_Implementations
+
+    click Logger_Core href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Logger_Core.md" "Details"
+
+    click Handler_Dispatcher href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Handler_Dispatcher.md" "Details"
+
+    click Sink_Implementations href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Sink_Implementations.md" "Details"
+
+    click Exception_Formatting_Utilities href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Exception_Formatting_Utilities.md" "Details"
+
+    click Log_Record_Configuration_Utilities href "https://github.com/Delgan/loguru/blob/main/.codeboarding//Log_Record_Configuration_Utilities.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The architecture of `loguru` is designed around a clear separation of concerns, enabling robust and flexible logging. Based on the Control Flow Graph (CFG) and Source Analysis, the system can be distilled into five fundamental components: Logger Core, Handler & Dispatcher, Sink Implementations, Exception & Formatting Utilities, and Log Record & Configuration Utilities. These components represent the core responsibilities and interaction points within the `loguru` library, handling everything from message creation and processing to output and advanced formatting, forming a cohesive and efficient logging architecture.
+
+
+
+### Logger Core
+
+This is the primary user-facing API and the central orchestrator of the Loguru logging system. It provides the public interface for users to emit log messages (e.g., `logger.info()`, `logger.debug()`), configure global logging behavior (adding/removing sinks, setting levels), and initiates the log processing pipeline for every message. It's the entry point for all logging operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_logger.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._logger` (1:10000)</a>
+
+
+
+
+
+### Handler & Dispatcher
+
+This component acts as an intermediary, receiving raw log records from the `Logger Core`. Its primary responsibilities include applying filtering based on severity level and custom rules, formatting the log message according to the handler's specific configuration, managing an optional multiprocessing-safe queue for non-blocking I/O operations, and then dispatching the final processed message to its designated `Sink Implementations`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_handler.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._handler` (1:10000)</a>
+
+
+
+
+
+### Sink Implementations
+
+This component represents a collection of concrete destinations for log output. It includes specialized `File Sink` implementations that provide robust file management features (automatic file rotation by size or time, retention policies, compression of archived log files), as well as `Stream & Callable Sinks` for writing to standard I/O streams, executing arbitrary Python callable functions for custom handling, or adapting Loguru records to be compatible with Python's built-in `logging` module handlers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_file_sink.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._file_sink` (1:10000)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_simple_sinks.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._simple_sinks` (1:10000)</a>
+
+
+
+
+
+### Exception & Formatting Utilities
+
+This component is dedicated to enhancing the visual presentation and debuggability of log messages. It processes and renders Python exception tracebacks in a more user-friendly and informative manner, including extracting detailed frame information, highlighting relevant code lines, and displaying variable values. Additionally, it manages the application and parsing of ANSI escape codes for colored terminal output, ensuring messages are visually distinct and readable.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_better_exceptions.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._better_exceptions` (1:10000)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_colorizer.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._colorizer` (1:10000)</a>
+
+
+
+
+
+### Log Record & Configuration Utilities
+
+This component provides the foundational data structures and helper functions that support the core logging process and configuration. It is responsible for dynamically constructing the comprehensive dictionary (`record`) that accompanies each log message (gathering contextual data like time, file info, process/thread IDs, and exception details). It also offers various utility functions for parsing human-readable strings for durations, sizes, and frequencies (used in file rotation/retention), formatting datetime objects, and implementing diverse filtering strategies for log messages.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_recattrs.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._recattrs` (1:10000)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_datetime.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._datetime` (1:10000)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_string_parsers.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._string_parsers` (1:10000)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_filters.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._filters` (1:10000)</a>
+
+- <a href="https://github.com/Delgan/loguru/blob/master/loguru/_defaults.py#L1-L10000" target="_blank" rel="noopener noreferrer">`loguru._defaults` (1:10000)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR introduces diagram visualization for loguru's codebase. You can see how the diagram renders here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/loguru/on_boarding.md

The diagram documentation aims to ease the onboarding of new contributors. We believe that when starting at a new codebase one starts with a small component, but needs the big picture and the context of how that small component works within the big codebase. The diagram gives a good overview of what the main components are and how they interact with each other, then you can click on a component and get the same thing for that component. This way one can easily navigate to the related files of their first task and have the context of how they fit in the big picture. Let me know if this resonates with you!

We’ve also released a free GitHub Action that keeps the diagrams automatically updated as the code changes, so there's no ongoing maintenance burden.

Any feedback is more than welcome!

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.