### PR TITLE
Fix CI failures due to deprecated Ubuntu runners in Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,14 @@ jobs:
         allow-failure:
         - false
         include:
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           python-version: '3.5'
           allow-failure: false
-        - os: ubuntu-20.04
+          container: python:3.5-slim
+        - os: ubuntu-22.04
           python-version: '3.6'
           allow-failure: false
+          container: python:3.6-slim
         - os: windows-2022
           python-version: '3.12'
           allow-failure: false
@@ -42,16 +44,18 @@ jobs:
           python-version: 3.14-dev
           allow-failure: true
     runs-on: ${{ matrix.os }}
+    # Some versions of Python are not longer supported by GitHub Actions.
+    # For those, we use a container image and skip the setup-python step.
+    # It will be empty and ignored for the other matrix entries.
+    container: ${{ matrix.container }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Set up Python
+      if: ${{ matrix.container == null }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        # Workaround for https://github.com/actions/setup-python/issues/866
-        PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -60,11 +64,23 @@ jobs:
       run: |
         tox -e tests
       continue-on-error: ${{ matrix.allow-failure }}
-    - name: Upload coverage to Codecov
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.python-version }}-${{ matrix.os }}
+        path: coverage.xml
+      continue-on-error: ${{ matrix.allow-failure }}
+  push-coverage-to-codecov:
+    runs-on: ubuntu-22.04
+    needs: tests
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+    - name: Upload to Codecov
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        flags: ${{ matrix.os }}_${{ matrix.python-version }}
         verbose: true
         fail_ci_if_error: true
-      continue-on-error: ${{ matrix.allow-failure }}


### PR DESCRIPTION
The "ubuntu-20.04" runner was removed a few months ago, causing the Loguru CI to repeatedly fail since then. On top of that, migrating to "ubuntu-22.04" or "ubuntu-24.04" was not straightforward because these runners were incompatible with "actions/setup-python" for Python 3.5 and 3.6.

As a workaround, I replaced "actions/setup-python" with a "python-slim" Docker image for these versions that went unsupported. That's probably the closest we can get to a stable and reproducible CI setup that won't break overnight due to upstream decisions. ;)

Eventually, this solution will likely need to be repeated for other Python versions as theyh become deprecated. I've considered defaulting to a Docker image, but I assume the recommended approach is still to favor "actions/setup-python" when it's available.

Additionally, because "actions/download-artifact" would not work within the Docker image (conflicting GLIB versions between the OS and their executable), I've moved the Codecov upload to a later stage in charge of uploading all the coverage reports once the tests have been completed.

The downside is that we lose the "flags" that enabled us to identify coverage reports individually on Codecov. But I don't know if we can do otherwise.