### PR TITLE
WIP: Expose the default format as `DEFAULT_FORMAT`

### DIFF
--- a/loguru/__init__.py
+++ b/loguru/__init__.py
@@ -10,10 +10,11 @@ import sys as _sys
 from . import _defaults
 from ._logger import Core as _Core
 from ._logger import Logger as _Logger
+from ._defaults import DEFAULT_FORMAT
 
 __version__ = "0.7.3"
 
-__all__ = ["logger"]
+__all__ = ["logger", "DEFAULT_FORMAT"]
 
 logger = _Logger(
     core=_Core(),

--- a/loguru/_defaults.py
+++ b/loguru/_defaults.py
@@ -28,13 +28,15 @@ def env(key, type_, default=None):
 
 
 LOGURU_AUTOINIT = env("LOGURU_AUTOINIT", bool, True)
-
+DEFAULT_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss.SSS Z}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+)
 LOGURU_FORMAT = env(
     "LOGURU_FORMAT",
     str,
-    "<green>{time:YYYY-MM-DD HH:mm:ss.SSS Z}</green> | "
-    "<level>{level: <8}</level> | "
-    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+    DEFAULT_FORMAT,
 )
 LOGURU_FILTER = env("LOGURU_FILTER", str, None)
 LOGURU_LEVEL = env("LOGURU_LEVEL", str, "DEBUG")


### PR DESCRIPTION
I tend to have a quick solution to expose my logging with 
```python
_ = logger.remove()
_ = logger.add(sys.stderr, format=f"{_defaults.LOGURU_FORMAT} | {{extra}}")
```

However, accessing private modules is not ideal for code review or API stability. This will expose the format so I can extend it when specifying logging formats.

I'm also thinking this might be nice to have in the formatting step, so that we could define a message as

```python
_ = logger.remove()
_ = logger.add(sys.stderr, format="{defalt_format} | {extra}")
```

Thoughts welcome - could just be a me thing.