### PR TITLE
Document better snippet for Pytest compatibility

### DIFF
--- a/docs/resources/recipes.rst
+++ b/docs/resources/recipes.rst
@@ -1083,7 +1083,12 @@ Another thing to keep in mind when dealing with multiprocessing is the fact that
 Unit testing logs emitted by Loguru
 -----------------------------------
 
-Logging calls can be tested using |logot|_, a high-level log testing library with built-in support for Loguru::
+When migrating an existing project from standard :mod:`logging`, it can be useful to migrate your existing test cases too. In particular, you may want to:
+
+- Migrate ``assertLogs()`` from :mod:`unittest` to Loguru: :ref:`migration-assert-logs`
+- Migrate ``caplog`` from |pytest|_ to Loguru: :ref:`migration-caplog`
+
+Alternatively, logging calls can be tested using |logot|_, a high-level log testing library with built-in support for Loguru::
 
     from logot import Logot, logged
 
@@ -1103,9 +1108,3 @@ Enable Loguru log capture in your |pytest|_ configuration:
     See `using logot with Loguru <https://logot.readthedocs.io/latest/integrations/loguru.html>`_ for more information
     about `configuring pytest <https://logot.readthedocs.io/latest/integrations/loguru.html#enabling-for-pytest>`_
     and `configuring unittest <https://logot.readthedocs.io/latest/integrations/loguru.html#enabling-for-unittest>`_.
-
-.. note::
-
-    When migrating an existing project from standard :mod:`logging`, it can be useful to migrate your existing test
-    cases too. See :ref:`migrating assertLogs() <migration-assert-logs>` and :ref:`migrating caplog <migration-caplog>`
-    for more information.


### PR DESCRIPTION
Fix #1406.

Integration of Loguru logs with Pytest was a bit convoluted. Pytest implements and installs various logging handlers that serve different purposes. Example with the following code:

```python
import logging

logger = logging.getLogger("test_logger")


def test_something(caplog):
    logger.debug("ERROR_DEBUG")
    logger.error("ERROR_TEST")
    assert "ERROR_DEBUG" in caplog.text
```
Pytest command:
```bash
pytest test_log.py --log-cli-level INFO
```
Result:
```
========================================================================= test session starts =========================================================================
platform linux -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/delgan/Documents/code/loguru
configfile: pyproject.toml
plugins: mypy-plugins-3.2.0, cov-6.2.1, anyio-4.10.0
collected 1 item                                                                                                                                                      

test_log.py::test_something 
---------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------
ERROR    test_logger:test_log.py:8 ERROR_TEST
FAILED                                                                                                                                                          [100%]

============================================================================== FAILURES ===============================================================================
___________________________________________________________________________ test_something ____________________________________________________________________________

caplog = <_pytest.logging.LogCaptureFixture object at 0x7ffbf44270e0>

    def test_something(caplog):
        logger.debug("ERROR_DEBUG")
        logger.error("ERROR_TEST")
>       assert "ERROR_DEBUG" in caplog.text
E       AssertionError: assert 'ERROR_DEBUG' in 'ERROR    test_logger:test_log.py:8 ERROR_TEST\n'
E        +  where 'ERROR    test_logger:test_log.py:8 ERROR_TEST\n' = <_pytest.logging.LogCaptureFixture object at 0x7ffbf44270e0>.text

caplog     = <_pytest.logging.LogCaptureFixture object at 0x7ffbf44270e0>

test_log.py:9: AssertionError
-------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------
ERROR    test_logger:test_log.py:8 ERROR_TEST
======================================================================= short test summary info =======================================================================
FAILED test_log.py::test_something - AssertionError: assert 'ERROR_DEBUG' in 'ERROR    test_logger:test_log.py:8 ERROR_TEST\n'
========================================================================== 1 failed in 0.04s ==========================================================================
```

The " live log call" section comes from the `--log-cli-level INFO` option. The "Captured log call" section comes from a reporting handler. Pytest handlers are integrated with the standard logging system, which means they depend both on their own level and on the root logger's level which default to "WARNING". Using `--log-cli-level` or `caplog.set_level()` changes these levels and therefore cause different outputs. These handlers are not totally independent. Actually, using `--log-cli-level DEBUG` would make the above test to succeed, although it's only supposed to change the "live logs" and not the "caplog" ones.

Anyway, I figured out the best way to integrate Loguru with Pytest was to access these handlers directly instead of trying to install a `PropagateHandler` or overriding the `caplog` fixture. The new suggested solution looks cleaner and generic (only need one fixture).

Important note: we're now bypassing the root logger's level, which means that all logs will be sent to the Pytest handlers (which by default do not have any level set up). This can increase verbosity, but I think this is the right approach. It's totally possible for users to reduce the verbosity by explicitly configuring the level of the Loguru sink or of the Pytest handlers.