### PR TITLE
Document anonymous log level for `log()`

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -69,6 +69,8 @@
 .. _multiprocessing.Context:
    https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
 
+.. _FAQ anonymous levels: https://loguru.readthedocs.io/en/latest/resources/troubleshooting.html#why-isn-t-the-level-name-shown-when-using-an-integer-or-a-built-in-level
+
 .. |better_exceptions| replace:: ``better_exceptions``
 .. _better_exceptions: https://github.com/Qix-/better-exceptions
 
@@ -2200,7 +2202,11 @@ class Logger:
         __self._log("ERROR", False, options, __message, args, kwargs)
 
     def log(__self, __level, __message, *args, **kwargs):  # noqa: N805
-        r"""Log ``message.format(*args, **kwargs)`` with severity ``level``."""
+        r"""Log ``message.format(*args, **kwargs)`` with severity ``level``.
+
+        Note that if an |int| is provided as ``level``, the level is interpreted as an anonymous
+        one and displayed as such (see also `FAQ anonymous levels`_ for more details).
+        """
         __self._log(__level, False, __self._options, __message, args, kwargs)
 
     def start(self, *args, **kwargs):


### PR DESCRIPTION
This change adds the info about how integer log levels are interpreted
when using `logger.log(10, ...)` and link to the related FAQ entry.

Related to #1411