### PR TITLE
Add `template` to record

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@
 - Make ``logger.catch()`` usable as an asynchronous context manager (`#1084 <https://github.com/Delgan/loguru/issues/1084>`_).
 - Make ``logger.catch()`` compatible with asynchronous generators (`#1302 <https://github.com/Delgan/loguru/issues/1302>`_).
 - Improve feedback for invalid format keys in logger format strings (`#1450 <https://github.com/Delgan/loguru/issues/1450>`_, thanks `@Krishnachaitanyakc <https://github.com/Krishnachaitanyakc>`_).
+- Add ``record["template"]`` that includes the raw, unformatted message (`#1349 <https://github.com/Delgan/loguru/issues/1349>`_).
 
 
 `0.7.3`_ (2024-12-06)

--- a/loguru/__init__.pyi
+++ b/loguru/__init__.pyi
@@ -112,6 +112,7 @@ class Record(TypedDict):
     module: str
     name: Optional[str]
     process: RecordProcess
+    template: str
     thread: RecordThread
     time: datetime
 

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -297,6 +297,7 @@ class Handler:
                 "module": record["module"],
                 "name": record["name"],
                 "process": {"id": record["process"].id, "name": record["process"].name},
+                "template": record["template"],
                 "thread": {"id": record["thread"].id, "name": record["thread"].name},
                 "time": {"repr": record["time"], "timestamp": record["time"].timestamp()},
             },

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -2150,6 +2150,7 @@ class Logger:
             "module": splitext(file_name)[0],
             "name": name,
             "process": RecordProcess(process.ident, process.name),
+            "template": str(message),
             "thread": RecordThread(thread.ident, thread.name),
             "time": current_datetime,
         }

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -201,6 +201,31 @@ def test_non_string_message_is_str_in_record(writer, colors):
     assert output == "[123]\n"
 
 
+def test_template_vs_message_with_formatting(writer):
+    logger.add(writer, format="{template} | {message}")
+    logger.info("Hello {name}", name="World")
+
+    assert writer.read() == "Hello {name} | Hello World\n"
+
+
+@pytest.mark.parametrize(
+    ("message", "args", "kwargs", "expected_template", "expected_message"),
+    [
+        ("{} + {} = {}", [1, 2, 3], {}, "{} + {} = {}", "1 + 2 = 3"),
+        ("{a} + {b} = {c}", [], {"a": 1, "b": 2, "c": 3}, "{a} + {b} = {c}", "1 + 2 = 3"),
+        ("{0} + {two} = {1}", [1, 3], {"two": 2}, "{0} + {two} = {1}", "1 + 2 = 3"),
+        ("{:.2f}", [1], {}, "{:.2f}", "1.00"),
+    ],
+)
+def test_template_preserves_unformatted_message(
+    writer, message, args, kwargs, expected_template, expected_message
+):
+    logger.add(writer, format="{template} | {message}", colorize=False)
+    logger.info(message, *args, **kwargs)
+
+    assert writer.read() == "{} | {}\n".format(expected_template, expected_message)
+
+
 @pytest.mark.parametrize("colors", [True, False])
 def test_missing_positional_field_during_formatting(writer, colors):
     logger.add(writer)


### PR DESCRIPTION
`template` contains the raw, unformatted message body before any colorization or interpolation is applied. Useful for structured logging tools/visualizers like Sentry.

Hope I covered everything -- I'm available for changes if anything is off. 🙏🏻 

Ref https://github.com/Delgan/loguru/issues/1349