### PR TITLE
Add bounded queue support for enqueue option

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -302,10 +302,19 @@ class Logger:
         diagnose : |bool|, optional
             Whether the exception trace should display the variables values to ease the debugging.
             This should be set to ``False`` in production to avoid leaking sensitive data.
-        enqueue : |bool|, optional
+        enqueue : |bool|, |int| or |dict|, optional
             Whether the messages to be logged should first pass through a multiprocessing-safe queue
             before reaching the sink. This is useful while logging to a file through multiple
             processes. This also has the advantage of making logging calls non-blocking.
+
+            If ``True``, an unbounded queue is used (original behavior). If an ``int`` is passed,
+            it specifies the maximum queue size (bounded queue). When the queue is full, logging
+            calls will block until space is available.
+
+            A ``dict`` can be passed for more control with the following keys:
+                - ``"size"`` (int): Maximum queue size. ``0`` means unbounded.
+                - ``"overflow"`` (str): What to do when the queue is full.
+                  ``"block"`` (default) waits for space, ``"drop"`` silently discards the message.
         context : |multiprocessing.Context| or |str|, optional
             A context object or name that will be used for all tasks involving internally the
             |multiprocessing| module, in particular when ``enqueue=True``. If ``None``, the default


### PR DESCRIPTION
 PR Title

  Add bounded queue support for enqueue option (#1419)

  ## Summary

  This PR adds support for bounded queues when using `enqueue` to prevent unbounded memory growth with slow sinks.

  Fixes #1419

  ## Changes

  ### New `enqueue` options:

  | Usage | Description |
  |-------|-------------|
  | `enqueue=True` | Unbounded queue (existing behavior) |
  | `enqueue=100` | Bounded queue with max size 100, blocks when full |
  | `enqueue={"size": 100}` | Same as above |
  | `enqueue={"size": 100, "overflow": "block"}` | Blocks when full (default) |
  | `enqueue={"size": 100, "overflow": "drop"}` | Drops messages when full |

  ### Overflow policies:
  - `"block"` (default): Blocks logging call until queue has space (backpressure)
  - `"drop"`: Silently drops the message when queue is full (non-blocking)

  ## Example

  ```python
  from loguru import logger

  # Bounded queue that blocks when full
  logger.add("file.log", enqueue=100)

  # Bounded queue that drops messages when full
  logger.add("file.log", enqueue={"size": 100, "overflow": "drop"})

  Test Plan

  - Added 4 new test cases for bounded queue functionality
  - All 19 existing enqueue tests pass
  - Tested on macOS and Linux (Docker)