### PR TITLE
Fix crash when traceback frame has tb_lineno=None

### DIFF
--- a/loguru/_better_exceptions.py
+++ b/loguru/_better_exceptions.py
@@ -208,7 +208,11 @@ class ExceptionFormatter:
         def get_info(frame, lineno):
             filename = frame.f_code.co_filename
             function = frame.f_code.co_name
-            source = linecache.getline(filename, lineno).strip()
+            # Guard against None lineno (edge case on Python 3.12+, see CPython #139531)
+            if lineno is None:
+                source = ""
+            else:
+                source = linecache.getline(filename, lineno).strip()
             return filename, lineno, function, source
 
         infos = []


### PR DESCRIPTION
## Summary

- Fixes TypeError crash when formatting exceptions where a traceback frame has `tb_lineno=None`
- Guards against `None` lineno values by returning an empty source string instead of calling `linecache.getline()`

## Details

When formatting exceptions, Loguru calls `linecache.getline(filename, lineno)` with the line number from traceback frames. In some edge cases on Python 3.12+, `tb_lineno` can be `None` (see CPython issues python/cpython#139531 and python/cpython#89726), which causes a TypeError:

```
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```

This happens because `linecache.getline()` compares `lineno` with integers.

## Fix

The fix guards against `None` lineno values in the `get_info()` function:

```python
if lineno is None:
    source = ""
else:
    source = linecache.getline(filename, lineno).strip()
```

This allows exceptions to be logged even when the source line cannot be retrieved for frames with `None` lineno.

## Test plan

- [x] Manually verified the fix handles `None` lineno gracefully
- [x] The fix is minimal and targeted

Fixes #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)