### PR TITLE
Fix 'x' timestamp token double-counting microseconds

### DIFF
--- a/loguru/_datetime.py
+++ b/loguru/_datetime.py
@@ -109,7 +109,7 @@ def _compile_format(spec):
         "ZZ": ("%s", lambda t, dt: _format_timezone(dt, sep="")),
         "zz": ("%s", lambda t, dt: (dt.tzinfo or timezone.utc).tzname(dt) or ""),
         "X": ("%d", lambda t, dt: dt.timestamp()),
-        "x": ("%d", lambda t, dt: int(dt.timestamp() * 1000000 + dt.microsecond)),
+        "x": ("%d", lambda t, dt: int(dt.timestamp() * 1000000)),
     }
 
     format_string = ""


### PR DESCRIPTION
## Summary

The `x` datetime format token (microseconds timestamp) double-counts microseconds because `datetime.timestamp()` already includes them in the returned float.

## The Bug

In `_datetime.py`, the `x` token is computed as:

```python
"x": ("%d", lambda t, dt: int(dt.timestamp() * 1000000 + dt.microsecond)),
```

`datetime.timestamp()` returns a float like `1234567890.123` where `.123` represents 123000 microseconds. Multiplying by 1,000,000 gives `1234567890123000` — the microseconds are already included. Adding `dt.microsecond` (123000) on top double-counts them:

```python
>>> from datetime import datetime, timezone
>>> dt = datetime(2009, 2, 13, 23, 31, 30, 123000, tzinfo=timezone.utc)
>>> int(dt.timestamp() * 1000000 + dt.microsecond)
1234567890246000  # wrong
>>> int(dt.timestamp() * 1000000)
1234567890123000  # correct
```

The error equals the microsecond component (0–999999 μs, so up to ~1 second off).

## The Fix

Remove the redundant `+ dt.microsecond`:

```python
"x": ("%d", lambda t, dt: int(dt.timestamp() * 1000000)),
```

Note that the `X` token (seconds timestamp) on the line above is correct — it just uses `dt.timestamp()` without any adjustments.
