### PR TITLE
Fix wrong attribute name in Handler.__getstate__

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -324,7 +324,7 @@ class Handler:
         if self._enqueue:
             state["_sink"] = None
             state["_thread"] = None
-            state["_owner_process"] = None
+            state["_owner_process_pid"] = None
             state["_queue_lock"] = None
         return state
 


### PR DESCRIPTION
## Summary

`Handler.__getstate__` clears the wrong attribute name when preparing for pickling, leaving the real PID in the state and creating a spurious key.

## The Bug

In `_handler.py`, line 327:

```python
state["_owner_process"] = None  # <-- wrong name
```

The actual attribute defined in `__init__` (and used in `stop()` and `emit()`) is `_owner_process_pid`:

```python
# __init__, line 76/101:
self._owner_process_pid = None
self._owner_process_pid = os.getpid()

# stop(), line 216:
if self._owner_process_pid != os.getpid():

# emit(), line 235:
if self._enqueue and self._owner_process_pid != os.getpid():
```

Because of the typo, `__getstate__` doesn't clear `_owner_process_pid` — it stays in the pickled state with the original PID. It also introduces a spurious `_owner_process` key that no other code references.

## Impact

After unpickling a handler in the same process (same PID), calling `stop()` passes the `_owner_process_pid != os.getpid()` guard and tries to call `.join()` on `self._thread` which is `None` (because `__getstate__` correctly cleared `_thread`), causing an `AttributeError`.

## The Fix

```python
state["_owner_process_pid"] = None  # was: state["_owner_process"]
```
