### PR TITLE
Provide fallback for multiprocessing if it's not properly available

### DIFF
--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -1,6 +1,5 @@
 import functools
 import json
-import multiprocessing
 import os
 import threading
 from contextlib import contextmanager
@@ -89,6 +88,8 @@ class Handler:
                 self._decolorized_format = self._formatter.strip()
 
         if self._enqueue:
+            import multiprocessing
+
             if self._multiprocessing_context is None:
                 self._queue = multiprocessing.SimpleQueue()
                 self._confirmation_event = multiprocessing.Event()

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -100,14 +100,13 @@ import builtins
 import contextlib
 import functools
 import logging
+import os
 import re
 import sys
 import threading
 import warnings
 from collections import namedtuple
 from inspect import isclass, iscoroutinefunction, isgeneratorfunction
-from multiprocessing import current_process, get_context
-from multiprocessing.context import BaseContext
 from os.path import basename, splitext
 from threading import current_thread
 
@@ -1011,12 +1010,17 @@ class Logger:
             encoding = "ascii"
 
         if isinstance(context, str):
+            from multiprocessing import get_context
+
             context = get_context(context)
-        elif context is not None and not isinstance(context, BaseContext):
-            raise TypeError(
-                "Invalid context, it should be a string or a multiprocessing context, "
-                "not: '%s'" % type(context).__name__
-            )
+        elif context is not None:
+            from multiprocessing.context import BaseContext
+
+            if not isinstance(context, BaseContext):
+                raise TypeError(
+                    "Invalid context, it should be a string or a multiprocessing context, "
+                    "not: '%s'" % type(context).__name__
+                )
 
         with self._core.lock:
             exception_formatter = ExceptionFormatter(
@@ -2096,7 +2100,11 @@ class Logger:
 
         file_name = basename(co_filename)
         thread = current_thread()
-        process = current_process()
+        process_id = os.getpid()
+        try:
+            process_name = sys.modules["multiprocessing"].current_process().name
+        except KeyError:
+            process_name = "MainProcess"
         elapsed = current_datetime - start_time
 
         if exception:
@@ -2121,7 +2129,7 @@ class Logger:
             "message": str(message),
             "module": splitext(file_name)[0],
             "name": name,
-            "process": RecordProcess(process.ident, process.name),
+            "process": RecordProcess(process_id, process_name),
             "thread": RecordThread(thread.ident, thread.name),
             "time": current_datetime,
         }


### PR DESCRIPTION
This PR addresses https://github.com/Delgan/loguru/issues/1444

Disclaimer: This was coded by AI (Claude Code with one of the Opus)
The changes are small enough that I confidently can say I understand the code changes and they seem reasonable to me.


Changes:
The biggest difference is using `os.getpid()`  instead of the multiprocessing `current_process().ident`. I think this should be equivalent, but I wanted to point this one out as  I am not super deep into multi processing and threading.


As mentioned in the issue, this is at the moment mainly targeted at [pyodide](https://pyodide.org). pyodide provides a way for python to run completely in the browser through webassembly. A minimal working example is the following (this requires to build the wheel of loguru, I built it with `python -m build`)

```html
<!doctype html>
<html>
  <head>
      <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
  </head>
  <body>
    Pyodide test page <br>
    Open your browser console to see Pyodide output

    <img id="png-output" width="800" height="600" style="display:none;" />
    <script type="text/javascript">
      function displayPngBase64(b64) {
        const img = document.getElementById("png-output");
        img.src = "data:image/png;base64," + b64;
        console.log(img.src)
        img.width = 800;
        img.height = 600;
        img.style.display = "block";
      }
    </script>
    <script type="text/javascript">
      async function main(){
        let pyodide = await loadPyodide();
        await pyodide.loadPackage("micropip");
        console.log(await pyodide.runPythonAsync(`
            import micropip

            await micropip.install("./loguru-0.7.3-py3-none-any.whl")

            import loguru
            import sys
            
            loguru.logger.add(sys.stdout)
            loguru.logger.warning("hello from loguru")
        
        `));
      }
      main();
    </script>
  </body>
</html>
```

This gets printed to the console of the browser after opening it in the browser (use `python -m http.server 8000` to serve it and go to `http://127.0.0.01:8000` to access it) and opening the developer interface to see console and its log output

<img width="2458" height="746" alt="image" src="https://github.com/user-attachments/assets/6d2c394f-acc3-4806-91fe-81425bd22ffa" />

TODO:

- Add tests. Maybe @pepijndevos could help out here. I am not very familiar with emscripten & pyodide, but I know pyodide provides a way to write tests for it
- I think it currently still can fail if the context is a string? I don't know yet how to change the context to that :P