### PR TITLE
Fix invalid state causing repeated "RuntimeError" of avoided deadlock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@
 - Fix possible internal error when dealing with (rare) frame objects missing a ``f_lineno`` value (`#1435 <https://github.com/Delgan/loguru/issues/1435>`_).
 - Fix a regression preventing formatting of ``record["time"]`` when using ``zoneinfo.ZoneInfo`` timezones (`#1260 <https://github.com/Delgan/loguru/pull/1260>`_, thanks `@bijlpieter <https://github.com/bijlpieter>`_).
 - Fix possible ``ValueError`` raised on Windows when system clock was set far ahead in the future (`#1291 <https://github.com/Delgan/loguru/issues/1291>`_).
+- Fix externally raised ``Exception`` possibly causing invalid state generating repeated ``RuntimeError`` of avoided deadlock (`#1335 <https://github.com/Delgan/loguru/issues/1335>`_).
 - Respect the ``.level`` attribute of standard logging ``Handler`` used as sink, which was previously ignored (`#1409 <https://github.com/Delgan/loguru/issues/1409>`_).
 - Allow the ``rotation`` argument of file sinks to accept a list of rotation conditions, any of which can trigger the rotation (`#1174 <https://github.com/Delgan/loguru/issues/1174>`_, thanks `@CollinHeist <https://github.com/CollinHeist>`_).
 - Honor the ``NO_COLOR`` environment variable which disables color output by default if ``colorize`` is not provided (`#1178 <https://github.com/Delgan/loguru/issues/1178>`_).

--- a/loguru/_handler.py
+++ b/loguru/_handler.py
@@ -117,8 +117,8 @@ class Handler:
                 "handler or a '__del__' method. This is not permitted because the logger and its "
                 "handlers are not re-entrant."
             )
-        self._lock_acquired.acquired = True
         try:
+            self._lock_acquired.acquired = True
             with self._lock:
                 yield
         finally:


### PR DESCRIPTION
Fix #1335.

If an exception happened between `self._lock_acquired.acquired = True` and `try`, the `_lock_acquired` boolean would be left indefinitely in the `True` state while never being reset by the `finally` clause.

Effectively, this means following logging calls would cause a `RuntimeError` to be raised although the lock was not acquired.

Such scenario can happen due to [`PyThreadState_SetAsyncExc`](https://docs.python.org/3/c-api/threads.html#c.PyThreadState_SetAsyncExc) function from the C API, since it can be used to throw exception from others threads.

Important: the `PyThreadState_SetAstncExc` is also the possible cause of true deadlocks. However, Loguru cannot do anything about these ones. This is because context manager such as `with lock` are not "atomic" at the Python bytecode level. Consequently, if an exception if raised at an unfortunate timing, the lock can be left in a locked state with Python never being able to release it.

See: https://discuss.python.org/t/is-there-a-safe-way-to-use-pythreadstate-setasyncexc-without-causing-deadlocks/