### PR TITLE
Add NumPy-style docstrings to _filters.py and _defaults.py

### DIFF
--- a/loguru/_defaults.py
+++ b/loguru/_defaults.py
@@ -2,6 +2,31 @@ from os import environ
 
 
 def env(key, type_, default=None):
+    """Read an environment variable and coerce it to the requested type.
+
+    Parameters
+    ----------
+    key : str
+        The name of the environment variable to read.
+    type_ : type
+        The type to coerce the value to. Supported types are ``str``, ``bool``,
+        and ``int``.
+    default : object, optional
+        The value to return when the environment variable is not set.
+        Defaults to ``None``.
+
+    Returns
+    -------
+    object
+        The coerced value of the environment variable, or ``default`` if the
+        variable is not set.
+
+    Raises
+    ------
+    ValueError
+        If the variable's value cannot be coerced to ``type_``, or if
+        ``type_`` is not one of the supported types.
+    """
     if key not in environ:
         return default
 

--- a/loguru/_filters.py
+++ b/loguru/_filters.py
@@ -1,8 +1,36 @@
 def filter_none(record):
+    """Determine whether a log record should pass based on its logger name.
+
+    Parameters
+    ----------
+    record : dict
+        The log record dictionary containing at least a ``"name"`` key.
+
+    Returns
+    -------
+    bool
+        ``True`` if the record's ``"name"`` is not ``None``, ``False`` otherwise.
+    """
     return record["name"] is not None
 
 
 def filter_by_name(record, parent, length):
+    """Determine whether a log record's name matches a given parent module prefix.
+
+    Parameters
+    ----------
+    record : dict
+        The log record dictionary containing at least a ``"name"`` key.
+    parent : str
+        The parent module name to match against, expected to end with ``"."``.
+    length : int
+        The number of characters to compare, typically ``len(parent)``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the record name starts with the parent prefix, ``False`` otherwise.
+    """
     name = record["name"]
     if name is None:
         return False
@@ -10,6 +38,25 @@ def filter_by_name(record, parent, length):
 
 
 def filter_by_level(record, level_per_module):
+    """Determine whether a log record meets the minimum level for its module.
+
+    The level is looked up by walking up the module hierarchy until a match is
+    found in ``level_per_module``. A value of ``False`` explicitly disables the
+    module; any other truthy numeric value sets the minimum level number.
+
+    Parameters
+    ----------
+    record : dict
+        The log record dictionary containing ``"name"`` and ``"level"`` keys.
+    level_per_module : dict
+        Mapping of module name to minimum level number, or ``False`` to disable.
+
+    Returns
+    -------
+    bool
+        ``True`` if the record's level meets or exceeds the configured minimum,
+        ``False`` if the module is explicitly disabled or the level is too low.
+    """
     name = record["name"]
 
     while True:


### PR DESCRIPTION
## Summary

This PR adds docstrings to previously undocumented functions in two internal modules, following the NumPy docstring convention already established throughout the codebase (e.g. `_recattrs.py`, `_string_parsers.py`).

**`loguru/_filters.py`** — documents all three filter functions:
- `filter_none` — passes records whose logger name is not `None`
- `filter_by_name` — matches records against a parent module name prefix
- `filter_by_level` — walks the module hierarchy to apply per-module level thresholds

**`loguru/_defaults.py`** — documents the `env()` helper:
- Describes the `key`, `type_`, and `default` parameters
- Documents the return value and the `ValueError` cases for invalid values or unsupported types

## Notes

- Documentation only — no logic, behavior, or algorithm changes
- All docstrings use the NumPy convention and stay within the project's 100-character doc line limit
- No test files were modified