### PR TITLE
Fix FileNotFoundError during rotation when log file is deleted extern…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@
 - Fix hex color short code expansion (`#1426 <https://github.com/Delgan/loguru/issues/1426>`_, thanks `@turkoid <https://github.com/turkoid>`_).
 - Fix possible internal error when dealing with (rare) frame objects missing a ``f_lineno`` value (`#1435 <https://github.com/Delgan/loguru/issues/1435>`_).
 - Fix a regression preventing formatting of ``record["time"]`` when using ``zoneinfo.ZoneInfo`` timezones (`#1260 <https://github.com/Delgan/loguru/pull/1260>`_, thanks `@bijlpieter <https://github.com/bijlpieter>`_).
+- Fix possible ``FileNotFoundError`` during file rotation if the log file is deleted externally (`#519 <https://github.com/Delgan/loguru/issues/519>`_, `#220 <https://github.com/Delgan/loguru/issues/220>`_).
 - Fix possible ``ValueError`` raised on Windows when system clock was set far ahead in the future (`#1291 <https://github.com/Delgan/loguru/issues/1291>`_).
 - Fix externally raised ``Exception`` possibly causing invalid state generating repeated ``RuntimeError`` of avoided deadlock (`#1335 <https://github.com/Delgan/loguru/issues/1335>`_).
 - Respect the ``.level`` attribute of standard logging ``Handler`` used as sink, which was previously ignored (`#1409 <https://github.com/Delgan/loguru/issues/1409>`_).

--- a/loguru/_file_sink.py
+++ b/loguru/_file_sink.py
@@ -277,11 +277,14 @@ class FileSink:
             self._create_dirs(new_path)
 
             if new_path == old_path:
-                creation_time = get_ctime(old_path)
-                root, ext = os.path.splitext(old_path)
-                renamed_path = generate_rename_path(root, ext, creation_time)
-                os.rename(old_path, renamed_path)
-                old_path = renamed_path
+                try:
+                    creation_time = get_ctime(old_path)
+                    root, ext = os.path.splitext(old_path)
+                    renamed_path = generate_rename_path(root, ext, creation_time)
+                    os.rename(old_path, renamed_path)
+                    old_path = renamed_path
+                except OSError:
+                    old_path = None
 
         if is_rotating or self._rotation_function is None:
             if self._compression_function is not None and old_path is not None:

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -1011,6 +1011,16 @@ def test_exception_during_rotation_not_caught(tmp_path, capsys):
     assert out == err == ""
 
 
+def test_rotation_missing_file_during_rename(tmp_path):
+    logger.add(tmp_path / "test.log", rotation=0, format="{message}", catch=False)
+    logger.info("1")
+    filepath = tmp_path / "test.log"
+    filepath.unlink()  # simulate external deletion while handle is still open
+    logger.info("2")  # should not raise
+    check_dir(tmp_path, size=2)
+    assert (tmp_path / "test.log").read_text() == "2\n"
+
+
 def test_recipe_rotation_both_size_and_time(freeze_time, tmp_path):
     class Rotator:
         def __init__(self, *, size, at):
@@ -1147,3 +1157,4 @@ def test_invalid_unit_rotation_duration(rotation):
 def test_invalid_value_rotation_duration(rotation):
     with pytest.raises(ValueError, match=r"^Invalid float value while parsing duration: '[^']+'$"):
         logger.add("test.log", rotation=rotation)
+


### PR DESCRIPTION
Closes #1471

### Problem
When a log file is deleted externally (e.g., by a tmp cleaner, or after a long sleep/wake cycle) while Loguru still holds an open file handle, the next message that triggers rotation crashes with `FileNotFoundError` inside `_terminate_file()`. This happens because `get_ctime()` and `os.rename()` assume the file still exists after `_close_file()` is called.

This race condition was previously reported in #519 and #220 but was never fully fixed — those issues were closed for unrelated reasons (async code changes and `enqueue=True` usage, respectively).

### Solution
Wrap the rotation-rename block in `_terminate_file()` with `try/except OSError`. If the file disappears during rotation:
- Skip the rename.
- Set `old_path = None` so compression is also skipped.
- Continue creating the new file and logging normally.

### Changes
- `loguru/_file_sink.py`: Added `try/except OSError` around the rotation-rename logic.
- `tests/test_filesink_rotation.py`: Added `test_rotation_missing_file_during_rename` which simulates external deletion by unlinking the file mid-logging.
- `CHANGELOG.rst`: Added entry under `Unreleased`.

### Verification
```bash
$ pytest tests/test_filesink_rotation.py -v
======================= 139 passed, 3 skipped in 31.03s ========================
```

### AI Disclosure
The reproduction script and initial fix were identified with the help of an AI assistant, then manually reviewed, tested, and verified by me.
