### PR TITLE
remove unnecessary python upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ keywords = ["loguru", "logging", "logger", "log"]
 license = { file = "LICENSE" }
 name = "loguru"
 readme = 'README.md'
-requires-python = ">=3.5,<4.0"
+requires-python = ">=3.5"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
There's more or less consensus these days that this upper bound in python-requires is undesirable, certainly for pure python projects.

The upper bound was added at #1140 migration to pyproject.toml