### PR TITLE
Fix parse_size docstring: it returns bytes, not bits

### DIFF
--- a/loguru/_string_parsers.py
+++ b/loguru/_string_parsers.py
@@ -100,7 +100,7 @@ class Frequencies:
 
 
 def parse_size(size: str) -> Optional[float]:
-    """Parse a size string with optional units into bits.
+    """Parse a size string with optional units into bytes.
 
     Supports formats like '100MB', '2GiB', '1.5TB'. Case insensitive.
 
@@ -112,7 +112,7 @@ def parse_size(size: str) -> Optional[float]:
     Returns
     -------
     float | None
-        Size in bits or None if invalid format.
+        Size in bytes or None if invalid format.
 
     Raises
     ------


### PR DESCRIPTION
The function's docstring claims it returns bits in two places, but
the implementation actually returns bytes:

- a bare \`b\` suffix (the bit-literal case) is divided by 8
- a \`B\` suffix passes through unchanged
- \`rotation_size\` in \`_file_sink.py\` compares the result against
  \`file.tell() + len(message)\`, which is bytes

So \`parse_size("10MB")\` returns 10,000,000, which is bytes. Fixed
the wording in both places.

Disclosure: AI assisted with reading through the file to find this.