### PR TITLE
Fix Record extra type annotation from Dict[Any, Any] to Dict[str, Any]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@
 - Make ``logger.catch()`` usable as an asynchronous context manager (`#1084 <https://github.com/Delgan/loguru/issues/1084>`_).
 - Make ``logger.catch()`` compatible with asynchronous generators (`#1302 <https://github.com/Delgan/loguru/issues/1302>`_).
 - Improve feedback for invalid format keys in logger format strings (`#1450 <https://github.com/Delgan/loguru/issues/1450>`_, thanks `@Krishnachaitanyakc <https://github.com/Krishnachaitanyakc>`_).
-
+- Fix type annotation of ``Record["extra"]`` from ``Dict[Any, Any]`` to ``Dict[str, Any]`` to reflect that keys are always strings, reducing spurious ``Any`` propagation in strictly-typed codebases (`#1482 <https://github.com/Delgan/loguru/issues/1482>`_).
 
 `0.7.3`_ (2024-12-06)
 =====================

--- a/loguru/__init__.pyi
+++ b/loguru/__init__.pyi
@@ -103,7 +103,7 @@ class RecordException(NamedTuple):
 class Record(TypedDict):
     elapsed: timedelta
     exception: Optional[RecordException]
-    extra: Dict[Any, Any]
+    extra: Dict[str, Any]
     file: RecordFile
     function: str
     level: RecordLevel
@@ -323,7 +323,7 @@ class Logger:
         *,
         handlers: Optional[Sequence[HandlerConfig]] = ...,
         levels: Optional[Sequence[LevelConfig]] = ...,
-        extra: Optional[Dict[Any, Any]] = ...,
+        extra: Optional[Dict[str, Any]] = ...,
         patcher: Optional[PatcherFunction] = ...,
         activation: Optional[Sequence[ActivationConfig]] = ...
     ) -> List[int]: ...

--- a/tests/typesafety/test_logger.yml
+++ b/tests/typesafety/test_logger.yml
@@ -333,7 +333,7 @@
     main:4: error: Extra key "baz" for TypedDict "LevelConfig"  [typeddict-unknown-key]
     main:5: error: Argument "patcher" to "configure" of "Logger" has incompatible type "int"; expected "Callable[[Record], None] | None"  [arg-type]
     main:6: error: List item 0 has incompatible type "dict[str, str]"; expected "tuple[str | None, bool]"  [list-item]
-    main:7: error: Argument "extra" to "configure" of "Logger" has incompatible type "list[int]"; expected "dict[Any, Any] | None"  [arg-type]
+    main:7: error: Argument "extra" to "configure" of "Logger" has incompatible type "list[int]"; expected "dict[str, Any] | None"  [arg-type]
 
 - case: reinstall
   main: |

--- a/tests/typesafety/test_record_extra.yml
+++ b/tests/typesafety/test_record_extra.yml
@@ -1,0 +1,37 @@
+- case: record_extra_keys_are_strings
+  main: |
+    from loguru import Record
+    def func(record: Record) -> None:
+        key: str = "user"
+        value = record["extra"][key]
+  out: ''
+
+- case: record_extra_rejects_integer_key
+  main: |
+    from loguru import Record
+    def func(record: Record) -> None:
+        value = record["extra"][123]
+  out: |
+    main:3: error: Invalid index type "int" for "dict[str, Any]"; expected type "str"  [index]
+
+- case: record_can_be_annotated_without_any_generics_error
+  main: |
+    from loguru import Record
+    def func(record: Record) -> None:
+        print(record)
+  mypy_config: |
+    disallow_any_generics = True
+
+- case: record_extra_update_with_string_keys
+  main: |
+    from loguru import Record
+    def patcher(record: Record) -> None:
+        record["extra"].update(request_id="abc123")
+        record["extra"]["user"] = "alice"
+  out: ''
+
+- case: configure_extra_accepts_string_keys
+  main: |
+    from loguru import logger
+    logger.configure(extra={"app": "myservice", "version": "1.0"})
+  out: ''


### PR DESCRIPTION
Fixes #1482

## What changed
- `Record["extra"]` retyped from `Dict[Any, Any]` to `Dict[str, Any]`
- `Logger.configure(extra=...)` retyped the same way
- Added `tests/typesafety/test_record_extra.yml` with 5 test cases

## Why
`bind(**kwargs)` only accepts string keyword arguments, so `Any` keys
were inaccurate. The `Any` key type caused mypy's `--disallow-any-generics`
to flag any function annotated with `Record` as tainted.
