### PR TITLE
Fix first rotation of "<weekday> at <time>" ignoring the weekday

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@
 - Add support for template strings used as log messages (`#1397 <https://github.com/Delgan/loguru/issues/1397>`_, thanks `@TurtleOrangina <https://github.com/TurtleOrangina>`_).
 - Fix incorrect microsecond value when formatting the log timestamp using ``{time:x}`` (`#1440 <https://github.com/Delgan/loguru/issues/1440>`_).
 - Fix parsing of 12-hour rotation times without seconds (`#1474 <https://github.com/Delgan/loguru/issues/1474>`_, thanks `@c-tonneslan <https://github.com/c-tonneslan>`_).
+- Fix a ``"<weekday> at <time>"`` rotation firing its first rotation on the creation day instead of the requested weekday when the time of day was later than the creation time (`#1484 <https://github.com/Delgan/loguru/pull/1484>`_).
 - Fix hex color short code expansion (`#1426 <https://github.com/Delgan/loguru/issues/1426>`_, thanks `@turkoid <https://github.com/turkoid>`_).
 - Fix possible internal error when dealing with (rare) frame objects missing a ``f_lineno`` value (`#1435 <https://github.com/Delgan/loguru/issues/1435>`_).
 - Fix a regression preventing formatting of ``record["time"]`` when using ``zoneinfo.ZoneInfo`` timezones (`#1260 <https://github.com/Delgan/loguru/pull/1260>`_, thanks `@bijlpieter <https://github.com/bijlpieter>`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@
 - Add support for template strings used as log messages (`#1397 <https://github.com/Delgan/loguru/issues/1397>`_, thanks `@TurtleOrangina <https://github.com/TurtleOrangina>`_).
 - Fix incorrect microsecond value when formatting the log timestamp using ``{time:x}`` (`#1440 <https://github.com/Delgan/loguru/issues/1440>`_).
 - Fix parsing of 12-hour rotation times without seconds (`#1474 <https://github.com/Delgan/loguru/issues/1474>`_, thanks `@c-tonneslan <https://github.com/c-tonneslan>`_).
-- Fix a ``"<weekday> at <time>"`` rotation firing its first rotation on the creation day instead of the requested weekday when the time of day was later than the creation time (`#1484 <https://github.com/Delgan/loguru/pull/1484>`_).
+- Fix a ``"<weekday> at <time>"`` rotation firing its first rotation on the creation day instead of the requested weekday when the time of day was later than the creation time (`#1484 <https://github.com/Delgan/loguru/pull/1484>`_, thanks `@gaoflow <https://github.com/gaoflow>`_).
 - Fix hex color short code expansion (`#1426 <https://github.com/Delgan/loguru/issues/1426>`_, thanks `@turkoid <https://github.com/turkoid>`_).
 - Fix possible internal error when dealing with (rare) frame objects missing a ``f_lineno`` value (`#1435 <https://github.com/Delgan/loguru/issues/1435>`_).
 - Fix a regression preventing formatting of ``record["time"]`` when using ``zoneinfo.ZoneInfo`` timezones (`#1260 <https://github.com/Delgan/loguru/pull/1260>`_, thanks `@bijlpieter <https://github.com/bijlpieter>`_).

--- a/loguru/_file_sink.py
+++ b/loguru/_file_sink.py
@@ -106,9 +106,10 @@ class Rotation:
         return file.tell() + len(message) > size_limit
 
     class RotationTime:
-        def __init__(self, step_forward, time_init=None):
+        def __init__(self, step_forward, time_init=None, weekday=None):
             self._step_forward = step_forward
             self._time_init = time_init
+            self._weekday = weekday
             self._limit = None
 
         def __call__(self, message, file):
@@ -136,7 +137,12 @@ class Rotation:
                         microsecond=time_init.microsecond,
                     )
 
-                    if limit <= start_time:
+                    # A weekday rotation's initial limit lands on the creation
+                    # day, which may not be the requested weekday; step forward
+                    # until it does, so the first rotation isn't on the start day.
+                    if limit <= start_time or (
+                        self._weekday is not None and limit.weekday() != self._weekday
+                    ):
                         limit = self._step_forward(limit)
 
                     if time_init.tzinfo is None:
@@ -341,7 +347,7 @@ class FileSink:
                 if time is None:
                     time = datetime.time(0, 0, 0)
                 step_forward = partial(Rotation.forward_weekday, weekday=day)
-                return Rotation.RotationTime(step_forward, time)
+                return Rotation.RotationTime(step_forward, time, weekday=day)
             raise ValueError("Cannot parse rotation from: '%s'" % rotation)
         if isinstance(rotation, (numbers.Real, decimal.Decimal)):
             return partial(Rotation.rotation_size, size_limit=rotation)

--- a/loguru/_file_sink.py
+++ b/loguru/_file_sink.py
@@ -91,10 +91,8 @@ class Rotation:
 
     @staticmethod
     def forward_weekday(t, weekday):
-        while True:
-            t += datetime.timedelta(days=1)
-            if t.weekday() == weekday:
-                return t
+        days = (weekday - t.weekday()) % 7 or 7
+        return t + datetime.timedelta(days=days)
 
     @staticmethod
     def forward_interval(t, interval):
@@ -106,10 +104,10 @@ class Rotation:
         return file.tell() + len(message) > size_limit
 
     class RotationTime:
-        def __init__(self, step_forward, time_init=None, weekday=None):
+        def __init__(self, step_forward, time_target=None, day_target=None):
             self._step_forward = step_forward
-            self._time_init = time_init
-            self._weekday = weekday
+            self._time_target = time_target
+            self._day_target = day_target
             self._limit = None
 
         def __call__(self, message, file):
@@ -123,29 +121,29 @@ class Rotation:
                     creation_time, tz=datetime.timezone.utc
                 )
 
-                time_init = self._time_init
-
-                if time_init is None:
+                if self._time_target is None:
                     limit = start_time.astimezone(record_time.tzinfo).replace(tzinfo=None)
                     limit = self._step_forward(limit)
                 else:
-                    tzinfo = record_time.tzinfo if time_init.tzinfo is None else time_init.tzinfo
+                    tzinfo = (
+                        record_time.tzinfo
+                        if self._time_target.tzinfo is None
+                        else self._time_target.tzinfo
+                    )
                     limit = start_time.astimezone(tzinfo).replace(
-                        hour=time_init.hour,
-                        minute=time_init.minute,
-                        second=time_init.second,
-                        microsecond=time_init.microsecond,
+                        hour=self._time_target.hour,
+                        minute=self._time_target.minute,
+                        second=self._time_target.second,
+                        microsecond=self._time_target.microsecond,
                     )
 
-                    # A weekday rotation's initial limit lands on the creation
-                    # day, which may not be the requested weekday; step forward
-                    # until it does, so the first rotation isn't on the start day.
-                    if limit <= start_time or (
-                        self._weekday is not None and limit.weekday() != self._weekday
-                    ):
+                    if self._day_target is not None and limit.weekday() != self._day_target:
+                        limit = Rotation.forward_weekday(limit, self._day_target)
+
+                    if limit <= start_time:
                         limit = self._step_forward(limit)
 
-                    if time_init.tzinfo is None:
+                    if self._time_target.tzinfo is None:
                         limit = limit.replace(tzinfo=None)
 
                 self._limit = limit
@@ -347,7 +345,7 @@ class FileSink:
                 if time is None:
                     time = datetime.time(0, 0, 0)
                 step_forward = partial(Rotation.forward_weekday, weekday=day)
-                return Rotation.RotationTime(step_forward, time, weekday=day)
+                return Rotation.RotationTime(step_forward, time, day)
             raise ValueError("Cannot parse rotation from: '%s'" % rotation)
         if isinstance(rotation, (numbers.Real, decimal.Decimal)):
             return partial(Rotation.rotation_size, size_limit=rotation)

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -165,6 +165,42 @@ def test_time_rotation(freeze_time, tmp_path, when, hours):
     assert content == ["a\n", "b\nc\n", "d\n", "e\n"]
 
 
+@pytest.mark.parametrize(
+    ("when", "expected"),
+    [
+        # Created on a Sunday at 12:00. When the rotation time of day is later
+        # than the creation time, the first rotation must still happen on the
+        # requested weekday rather than on the creation day (the weekday was
+        # previously ignored for the first rotation).
+        ("w1 at 13:00", ["a\nb\n", "c\n", "d\n"]),  # Tuesday
+        ("tuesday at 13:00", ["a\nb\n", "c\n", "d\n"]),  # Tuesday, named
+        ("monday at 13:00", ["a\n", "b\nc\n", "d\n"]),  # Monday
+        # When the rotation time is earlier than the creation time the weekday
+        # was already honored; this case must keep its existing behavior.
+        ("w3 at 11:00", ["a\nb\nc\n", "d\n"]),  # Thursday
+    ],
+)
+def test_weekday_rotation_first_rotation_on_requested_weekday(
+    freeze_time, tmp_path, when, expected
+):
+    with freeze_time("2017-06-18 12:00:00") as frozen:  # Sunday
+        i = logger.add(
+            tmp_path / "test_{time}.log",
+            format="{message}",
+            rotation=when,
+            mode="w",
+        )
+
+        for h, m in zip([1, 24, 24, 24 * 7], ["a", "b", "c", "d"]):
+            frozen.tick(delta=datetime.timedelta(hours=h))
+            logger.debug(m)
+
+        logger.remove(i)
+
+    content = [path.read_text() for path in sorted(tmp_path.iterdir())]
+    assert content == expected
+
+
 def test_time_rotation_dst(freeze_time, tmp_path):
     with freeze_time("2018-10-27 05:00:00", ("CET", 3600)):
         i = logger.add(tmp_path / "test_{time}.log", format="{message}", rotation="1 day")

--- a/tests/test_filesink_rotation.py
+++ b/tests/test_filesink_rotation.py
@@ -127,6 +127,10 @@ def test_size_rotation(freeze_time, tmp_path, size):
         ("sunday", [0.1, 24 * 7 - 10, 24, 24 * 6, 24 * 7]),
         ("SUNDAY at 11:00", [1, 24 * 7, 2, 24 * 7, 30 * 12]),
         ("sunDAY at 1:0:0.0 pm", [0.9, 0.2, 24 * 7 - 2, 3, 24 * 8]),
+        ("w1 at 13:00", [25, 24, 24, 144, 168]),
+        ("tuesday at 13:00", [25, 24, 24, 144, 168]),
+        ("monday at 13:00", [1, 24, 24, 144, 168]),
+        ("w3 at 11:00", [73, 22, 26, 166, 168]),
         (datetime.time(15), [2, 3, 19, 5, 24]),
         (datetime.time(18, 30, 11, 123), [1, 5.51, 20, 24, 40]),
         ("2 h", [1, 2, 0.9, 0.5, 10]),
@@ -163,42 +167,6 @@ def test_time_rotation(freeze_time, tmp_path, when, hours):
 
     content = [path.read_text() for path in sorted(tmp_path.iterdir())]
     assert content == ["a\n", "b\nc\n", "d\n", "e\n"]
-
-
-@pytest.mark.parametrize(
-    ("when", "expected"),
-    [
-        # Created on a Sunday at 12:00. When the rotation time of day is later
-        # than the creation time, the first rotation must still happen on the
-        # requested weekday rather than on the creation day (the weekday was
-        # previously ignored for the first rotation).
-        ("w1 at 13:00", ["a\nb\n", "c\n", "d\n"]),  # Tuesday
-        ("tuesday at 13:00", ["a\nb\n", "c\n", "d\n"]),  # Tuesday, named
-        ("monday at 13:00", ["a\n", "b\nc\n", "d\n"]),  # Monday
-        # When the rotation time is earlier than the creation time the weekday
-        # was already honored; this case must keep its existing behavior.
-        ("w3 at 11:00", ["a\nb\nc\n", "d\n"]),  # Thursday
-    ],
-)
-def test_weekday_rotation_first_rotation_on_requested_weekday(
-    freeze_time, tmp_path, when, expected
-):
-    with freeze_time("2017-06-18 12:00:00") as frozen:  # Sunday
-        i = logger.add(
-            tmp_path / "test_{time}.log",
-            format="{message}",
-            rotation=when,
-            mode="w",
-        )
-
-        for h, m in zip([1, 24, 24, 24 * 7], ["a", "b", "c", "d"]):
-            frozen.tick(delta=datetime.timedelta(hours=h))
-            logger.debug(m)
-
-        logger.remove(i)
-
-    content = [path.read_text() for path in sorted(tmp_path.iterdir())]
-    assert content == expected
 
 
 def test_time_rotation_dst(freeze_time, tmp_path):


### PR DESCRIPTION
### The bug

A `rotation="<weekday> at <time>"` rule fires its **first** rotation on the file's creation day instead of the requested weekday, when the sink is created on a different weekday at a time of day earlier than the target time.

```python
import datetime
from loguru import logger

# Sink created on a Sunday at 12:00, rotating every Tuesday at 13:00.
logger.add("app_{time}.log", rotation="tuesday at 13:00")
```

Started on Sunday 12:00, a spurious rotation fires that same **Sunday at 13:00** (producing an empty rotated file and starting a new one), before settling onto Tuesdays. Expected: nothing should rotate until **Tuesday 13:00**.

### Cause

In `Rotation.RotationTime.__call__`, the initial `limit` is set to the creation date at the target time of day. The weekday is carried only by `step_forward` (`forward_weekday`), which is applied **only when `limit <= start_time`**. When the target time of day is later than the creation time, `limit > start_time`, so the step is skipped and the limit stays on the creation day — the wrong weekday.

It only manifests when the creation weekday differs from the target weekday **and** the target time of day is later than the creation time, which no existing test exercised (they all start Sunday 12:00 with same-weekday or earlier-time rules).

### The fix

Track the requested weekday on `RotationTime` and also step forward when the initial limit lands on the wrong weekday, so the first rotation happens on the requested weekday. Daily and interval rotations (`weekday=None`) are unaffected.

### Tests

Added `test_weekday_rotation_first_rotation_on_requested_weekday`, parametrized over `"w1 at 13:00"`, `"tuesday at 13:00"`, `"monday at 13:00"` (the broken cases) and `"w3 at 11:00"` (a time-before-creation control that was already correct and must stay so). The three broken cases fail on `master` (a spurious empty file appears) and pass with the fix; the control is unchanged. The full `tests/test_filesink_rotation.py` suite stays green (137 passed, 9 skipped); `black` and `ruff` are clean; `CHANGELOG.rst` updated.

---

*Disclosure: this contribution was prepared with AI assistance under my direction; I reviewed and tested all of it before submitting.*
