### PR TITLE
fix: replace bare except with except Exception in _logger.py

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1352,7 +1352,7 @@ class Logger:
                                     return await self._gen.asend(value)
                                 except StopAsyncIteration:
                                     pass
-                                except:
+                                except Exception:
                                     raise
                             raise StopAsyncIteration
 


### PR DESCRIPTION

### Summary

In the async-generator context manager (`loguru/_logger.py`), a bare
`except:` re-raises after the `StopAsyncIteration` case is handled. A bare
except also catches `KeyboardInterrupt`/`SystemExit` before re-raising them,
which is unnecessary and hides intent.

Replace with `except Exception:` — behavior is identical (the handler always
re-raises), but only expected exceptions are intercepted.

### Verification

- `python -m py_compile loguru/_logger.py` → OK
- `grep -rn "except:" loguru/` → 0 remaining bare handlers

### Files changed

- `loguru/_logger.py` (1 line)