### PR TITLE
Coordinate threading tests with events instead of sleeps

### DIFF
--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,16 +1,21 @@
 import itertools
 import time
-from threading import Barrier, Thread
+from threading import Barrier, Event, Thread
 
 from loguru import logger
 
 
 class NonSafeSink:
-    def __init__(self, sleep_time, stop_time=0):
+    def __init__(self, sleep_time, stop_time=0, stopping=None):
         self.sleep_time = sleep_time
         self.stop_time = stop_time
         self.written = ""
         self.stopped = False
+        # Set once the sink is midway through an operation, so that another thread can
+        # act while it is still in progress without relying on timing. The "stopping"
+        # event can be shared between sinks to wait for the first one of a group.
+        self.writing = Event()
+        self.stopping = Event() if stopping is None else stopping
 
     def write(self, message):
         if self.stopped:
@@ -18,10 +23,12 @@ class NonSafeSink:
 
         length = len(message)
         self.written += message[:length]
+        self.writing.set()
         time.sleep(self.sleep_time)
         self.written += message[length:]
 
     def stop(self):
+        self.stopping.set()
         time.sleep(self.stop_time)
         self.stopped = True
 
@@ -64,7 +71,7 @@ def test_safe_adding_while_logging(writer):
 
     def thread_2():
         barrier.wait()
-        time.sleep(0.5)
+        sink_1.writing.wait()
         logger.add(sink_2, format="{message}", catch=False)
         logger.info("ccc{}ddd", next(counter))
 
@@ -95,7 +102,7 @@ def test_safe_removing_while_logging(capsys):
 
     def thread_2():
         barrier.wait()
-        time.sleep(0.5)
+        sink.writing.wait()
         logger.remove(i)
         logger.info("ccc{}ddd", next(counter))
 
@@ -144,8 +151,10 @@ def test_safe_removing_all_while_logging(capsys):
 def test_safe_slow_removing_all_while_logging(capsys):
     barrier = Barrier(2)
 
+    stopping = Event()
+
     for _ in range(10):
-        sink = NonSafeSink(0.1, 0.1)
+        sink = NonSafeSink(0.1, 0.1, stopping=stopping)
         logger.add(sink, format="{message}", catch=False)
 
     def thread_1():
@@ -154,7 +163,7 @@ def test_safe_slow_removing_all_while_logging(capsys):
 
     def thread_2():
         barrier.wait()
-        time.sleep(0.5)
+        stopping.wait()
         logger.info("Some message")
 
     threads = [Thread(target=thread_1), Thread(target=thread_2)]
@@ -173,7 +182,8 @@ def test_safe_slow_removing_all_while_logging(capsys):
 def test_safe_writing_after_removing(capsys):
     barrier = Barrier(2)
 
-    logger.add(NonSafeSink(1), format="{message}", catch=False)
+    sink_1 = NonSafeSink(1)
+    logger.add(sink_1, format="{message}", catch=False)
     i = logger.add(NonSafeSink(1), format="{message}", catch=False)
 
     def write():
@@ -182,7 +192,7 @@ def test_safe_writing_after_removing(capsys):
 
     def remove():
         barrier.wait()
-        time.sleep(0.5)
+        sink_1.writing.wait()
         logger.remove(i)
 
     threads = [Thread(target=write), Thread(target=remove)]


### PR DESCRIPTION

Closes #1467

Four tests in `tests/test_threading.py` used `time.sleep(0.5)` to land an operation in the middle of a slow sink's write. That ordering only holds while the machine keeps up, which is the concern raised in the issue — and free-threaded builds make it less safe still.

The sleeps are replaced with events that the sink sets itself, so the second thread proceeds exactly when the first is mid-operation rather than after a fixed delay.

`NonSafeSink` gains two events:

- `writing` — set after the first half of the message is written, immediately before the sink's simulated I/O delay
- `stopping` — set on entry to `stop()`, and shareable between sinks so a test can wait for the first of a group to begin stopping

The sink's own `time.sleep(self.sleep_time)` / `time.sleep(self.stop_time)` stay: those are the simulated slow I/O being tested, not coordination.

### Why not the version proposed in the issue

As you pointed out, waiting for `logger.info()` to *finish* would make the threads sequential and stop testing the interleaving. These events fire while the sink is still inside its delay, so `logger.add()` / `logger.remove()` still happen in parallel with an in-flight write — the same window `sleep(0.5)` was aiming at, without depending on the clock.

Per test:

| test | previously | now |
|---|---|---|
| `test_safe_adding_while_logging` | `sleep(0.5)` | `sink_1.writing.wait()` |
| `test_safe_removing_while_logging` | `sleep(0.5)` | `sink.writing.wait()` |
| `test_safe_slow_removing_all_while_logging` | `sleep(0.5)` | shared `stopping.wait()` across the ten sinks |
| `test_safe_writing_after_removing` | `sleep(0.5)` | `sink_1.writing.wait()` |

The last one needed a shared event because `logger.remove()` tears down ten sinks and which one stops first is not guaranteed; waiting on any single sink would reintroduce an assumption.

### Notes

Runtime is unchanged (~15s for the file). The removed sleeps overlapped the sinks' own delays, so this buys determinism rather than speed — worth saying since faster execution came up in the issue.

`tests/test_threading.py` passes, repeated three times to check for flakiness. `ruff check` and `black --check` are clean.
