### PR TITLE
Fix negative timezone offsets with sub-minute components formatted one minute too large

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@
 - Add support for template strings used as log messages (`#1397 <https://github.com/Delgan/loguru/issues/1397>`_, thanks `@TurtleOrangina <https://github.com/TurtleOrangina>`_).
 - Add ``record["template"]`` that includes the raw, unformatted message (`#1349 <https://github.com/Delgan/loguru/issues/1349>`_, thanks `@sentrivana <https://github.com/sentrivana>`_).
 - Fix incorrect microsecond value when formatting the log timestamp using ``{time:x}`` (`#1440 <https://github.com/Delgan/loguru/issues/1440>`_).
+- Fix negative timezone offsets with a sub-minute component being formatted one minute too large by ``{time:Z}`` and ``{time:ZZ}`` (`#1500 <https://github.com/Delgan/loguru/issues/1500>`_).
 - Fix parsing of 12-hour rotation times without seconds (`#1474 <https://github.com/Delgan/loguru/issues/1474>`_, thanks `@c-tonneslan <https://github.com/c-tonneslan>`_).
 - Fix a ``"<weekday> at <time>"`` rotation firing its first rotation on the creation day instead of the requested weekday when the time of day was later than the creation time (`#1484 <https://github.com/Delgan/loguru/pull/1484>`_, thanks `@gaoflow <https://github.com/gaoflow>`_).
 - Fix hex color short code expansion (`#1426 <https://github.com/Delgan/loguru/issues/1426>`_, thanks `@turkoid <https://github.com/turkoid>`_).

--- a/loguru/_datetime.py
+++ b/loguru/_datetime.py
@@ -41,7 +41,7 @@ def _format_timezone(dt, *, sep):
     tzinfo = dt.tzinfo or timezone.utc
     offset = tzinfo.utcoffset(dt).total_seconds()
     sign = "+" if offset >= 0 else "-"
-    (h, m), s = divmod(abs(offset // 60), 60), abs(offset) % 60
+    (h, m), s = divmod(abs(offset) // 60, 60), abs(offset) % 60
     z = "%s%02d%s%02d" % (sign, h, sep, m)
     if s > 0:
         if s.is_integer():

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -140,7 +140,9 @@ def test_formatting(writer, freeze_time, time_format, date, timezone, expected):
     [
         ("%Y-%m-%d %H-%M-%S %f %Z %z", 7230.099, "2018-06-09 01-02-03 000000 ABC +020030.099000"),
         ("YYYY-MM-DD HH-mm-ss zz Z ZZ", 6543, "2018-06-09 01-02-03 ABC +01:49:03 +014903"),
-        ("HH-mm-ss zz Z ZZ", -12345.06702, "01-02-03 ABC -03:26:45.067020 -032645.067020"),
+        ("HH-mm-ss zz Z ZZ", -12345.06702, "01-02-03 ABC -03:25:45.067020 -032545.067020"),
+        ("HH-mm-ss Z ZZ", -3661, "01-02-03 -01:01:01 -010101"),
+        ("HH-mm-ss Z ZZ", -2670, "01-02-03 -00:44:30 -004430"),
     ],
 )
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="Offset must be a whole number of minutes")


### PR DESCRIPTION
## Bug

`{time:Z}` and `{time:ZZ}` (and therefore the current `master` default format, which uses `Z`) format negative timezone offsets that have a non-zero sub-minute component exactly one minute too large.

For example, with an offset of `-01:01:01`:

```text
-01:02:01   # actual
-01:01:01   # expected
```

and for `Africa/Monrovia` at `1971-01-01` (historical offset UTC−00:44:30):

```text
-00:45:30   # actual
-00:44:30   # expected
```

Positive offsets and negative offsets that are an exact whole number of minutes are unaffected.

## Root cause

In `loguru/_datetime.py`, `_format_timezone` computed the whole-minute part as:

```python
(h, m), s = divmod(abs(offset // 60), 60), abs(offset) % 60
```

`offset` is `utcoffset(...).total_seconds()`, a float. Python's `//` floors toward −∞, so for a negative offset that is not an exact whole number of minutes, `offset // 60` steps one extra minute away from zero. The following `abs()` then preserves that extra minute, while the seconds component (`abs(offset) % 60`) is computed independently, producing an offset that is one minute too large.

`datetime.timezone` has supported second-level UTC offsets since Python 3.7, and such offsets occur in real IANA timezone history, so this is reachable in practice.

## Fix

Take the absolute value *before* the floor division so the minute count is derived consistently with the seconds component:

```python
(h, m), s = divmod(abs(offset) // 60, 60), abs(offset) % 60
```

This is a one-token change with no effect on positive offsets or negative whole-minute offsets.

## Testing

- The existing parametrized case `test_formatting_timezone_offset_down_to_the_second[... -12345.06702 ...]` asserted the incorrect value (`-03:26:45.067020`), which masked the bug. Its expectation is corrected to `-03:25:45.067020`.
- Added two negative sub-minute cases (`-3661` → `-01:01:01`, `-2670` → `-00:44:30`).
- The three negative-offset cases fail on the unpatched source and pass after the fix; positive/whole-minute cases are unchanged.

```
$ python -m pytest tests/test_datetime.py tests/test_filesink_rotation.py -q
51 passed
137 passed, 9 skipped
```

`ruff check` and `black --check` pass on the changed files.

Closes #1500