### PR TITLE
Fix new exception raised in async generator athrow() bypassing catch()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 `Unreleased`_
 =============
 
+- Fix exceptions raised by an async generator while handling an injected ``athrow()`` exception bypassing ``@logger.catch()`` (`#1503 <https://github.com/Delgan/loguru/issues/1503>`_).
 - Change the default log format to include the timezone offset since it produces less ambiguous logs (`#856 <https://github.com/Delgan/loguru/pull/856>`_, thanks `@tim-x-y-z <https://github.com/tim-x-y-z>`_).
 - Add new ``logger.reinstall()`` method to automatically set up the ``logger`` in spawned child processes (`#818 <https://github.com/Delgan/loguru/issues/818>`_, thanks `@monchin <https://github.com/monchin>`_).
 - Add support for template strings used as log messages (`#1397 <https://github.com/Delgan/loguru/issues/1397>`_, thanks `@TurtleOrangina <https://github.com/TurtleOrangina>`_).

--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1358,7 +1358,39 @@ class Logger:
                             raise StopAsyncIteration
 
                         async def athrow(self, *args, **kwargs):
-                            return await self._gen.athrow(*args, **kwargs)
+                            injected = self._normalize_thrown(*args)
+                            unhandled = None
+                            with catcher:
+                                try:
+                                    return await self._gen.athrow(injected)
+                                except StopAsyncIteration:
+                                    pass
+                                except BaseException as error:
+                                    if error is injected:
+                                        unhandled = error
+                                    else:
+                                        raise
+                            if unhandled is not None:
+                                raise unhandled
+                            raise StopAsyncIteration
+
+                        @staticmethod
+                        def _normalize_thrown(*args):
+                            if not args:
+                                return None
+                            exception = args[0]
+                            if isinstance(exception, BaseException):
+                                return exception
+                            if isclass(exception) and issubclass(exception, BaseException):
+                                value = args[1] if len(args) > 1 else None
+                                if value is None:
+                                    return exception()
+                                if isinstance(value, exception):
+                                    return value
+                                if isinstance(value, tuple):
+                                    return exception(*value)
+                                return exception(value)
+                            return None
 
                     def catch_wrapper(*args, **kwargs):
                         gen = function(*args, **kwargs)

--- a/tests/exceptions/source/modern/decorate_async_generator.py
+++ b/tests/exceptions/source/modern/decorate_async_generator.py
@@ -101,11 +101,41 @@ def test_decorate_async_generator_then_async_throw():
     asyncio.run(coro())
 
 
+def test_decorate_async_generator_athrow_with_new_error_reraised():
+    logged = []
+    logger.remove()
+    logger.add(lambda message: logged.append(message.record["message"]), format="{message}", colorize=False)
+
+    @logger.catch(reraise=True)
+    async def generator():
+        try:
+            yield 1
+        except TimeoutError:
+            raise RuntimeError("boom")
+
+    async def coro():
+        gen = generator()
+        await gen.asend(None)
+        try:
+            await gen.athrow(TimeoutError)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("RuntimeError not raised")
+
+    asyncio.run(coro())
+    assert len(logged) == 1
+
+    logger.remove()
+    logger.add(lambda m: None, format="", diagnose=True, backtrace=True, colorize=True)
+
+
 test_decorate_async_generator()
 test_decorate_async_generator_with_error()
 test_decorate_async_generator_with_error_reraised()
 test_decorate_async_generator_then_async_send()
 test_decorate_async_generator_then_async_throw()
+test_decorate_async_generator_athrow_with_new_error_reraised()
 
 logger.add(sys.stderr, format="{message}")
 logger.info("Done")


### PR DESCRIPTION
Closes #1503.

When a generator decorated with `logger.catch()` is an async generator, exceptions raised while it's resumed through `asend()` go through the configured catcher (logged, `onerror` called, optionally reraised). `athrow()` never had any of that: it just forwarded straight to the wrapped generator.

That's fine when the exception injected through `athrow()` propagates back out unhandled, since that's expected control flow rather than an error the decorator should be catching. But if the generator catches that injected exception and then raises a *different* exception while handling it, that new exception should go through the same catcher path as it would for `asend()`. Right now it doesn't, so it's silently never logged.

`athrow()` now normalizes whatever was passed in (class, class + value, or an instance, matching `athrow`'s own accepted forms) into a concrete exception instance, forwards that to the underlying generator, and checks identity on the way out:

- Same exception instance comes back out unhandled: passed through raw, exactly like before.
- A different exception comes out: routed through the catcher, so it's logged / triggers `onerror` / respects `reraise`, same as `asend()`.
- `StopAsyncIteration` (generator exhausted while handling the injected exception): passed through raw, mirroring how `asend()` already treats it.

This matters beyond direct `athrow()` calls since it's also how `contextlib.asynccontextmanager` propagates exceptions from an `async with` body back into the generator, so the bypass could show up in ordinary cleanup code without anyone calling `athrow()` by hand.

Added a regression test alongside the existing async generator decorator tests covering the case where a caught injected exception is handled by raising something new, verifying it's actually logged. Ran the full test suite plus black/ruff on the touched files.