### PR TITLE
Fix "@logger.catch()" ignoring errors raised by "athrow()"

### DIFF
--- a/loguru/_logger.py
+++ b/loguru/_logger.py
@@ -1358,7 +1358,12 @@ class Logger:
                             raise StopAsyncIteration
 
                         async def athrow(self, *args, **kwargs):
-                            return await self._gen.athrow(*args, **kwargs)
+                            with catcher:
+                                try:
+                                    return await self._gen.athrow(*args, **kwargs)
+                                except StopAsyncIteration:
+                                    pass
+                            raise StopAsyncIteration
 
                     def catch_wrapper(*args, **kwargs):
                         gen = function(*args, **kwargs)

--- a/tests/exceptions/output/modern/exception_formatting_async_generator_throw.txt
+++ b/tests/exceptions/output/modern/exception_formatting_async_generator_throw.txt
@@ -1,0 +1,40 @@
+
+Traceback (most recent call last):
+  File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 28, in <module>
+    op.send(None)
+  File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 14, in foo
+    yield a
+ValueError: Bug
+
+Traceback (most recent call last):
+
+  File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 28, in <module>
+    op.send(None)
+    │  └ <method 'send' of 'coroutine' objects>
+    └ <coroutine object Logger.catch.<locals>.Catcher.__call__.<locals>.AsyncGenCatchWrapper.athrow at 0xDEADBEEF>
+
+  File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 14, in foo
+    yield a
+          └ 1
+
+ValueError: Bug
+
+Traceback (most recent call last):
+> File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 28, in <module>
+    op.send(None)
+  File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 14, in foo
+    yield a
+ValueError: Bug
+
+Traceback (most recent call last):
+
+> File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 28, in <module>
+    op.send(None)
+    │  └ <method 'send' of 'coroutine' objects>
+    └ <coroutine object Logger.catch.<locals>.Catcher.__call__.<locals>.AsyncGenCatchWrapper.athrow at 0xDEADBEEF>
+
+  File "tests/exceptions/source/modern/exception_formatting_async_generator_throw.py", line 14, in foo
+    yield a
+          └ 1
+
+ValueError: Bug

--- a/tests/exceptions/source/modern/decorate_async_generator.py
+++ b/tests/exceptions/source/modern/decorate_async_generator.py
@@ -93,10 +93,31 @@ def test_decorate_async_generator_then_async_throw():
         await gen.asend(None)
         try:
             await gen.athrow(ValueError)
-        except ValueError:
+        except StopAsyncIteration:
             pass
         else:
-            raise AssertionError("ValueError not raised")
+            raise AssertionError("StopAsyncIteration not raised")
+
+    asyncio.run(coro())
+
+
+def test_decorate_async_generator_then_async_throw_with_handled_error():
+    @logger.catch
+    async def generator():
+        try:
+            yield 1
+        except ValueError:
+            pass
+
+    async def coro():
+        gen = generator()
+        await gen.asend(None)
+        try:
+            await gen.athrow(ValueError)
+        except StopAsyncIteration:
+            pass
+        else:
+            raise AssertionError("StopAsyncIteration not raised")
 
     asyncio.run(coro())
 
@@ -106,6 +127,7 @@ test_decorate_async_generator_with_error()
 test_decorate_async_generator_with_error_reraised()
 test_decorate_async_generator_then_async_send()
 test_decorate_async_generator_then_async_throw()
+test_decorate_async_generator_then_async_throw_with_handled_error()
 
 logger.add(sys.stderr, format="{message}")
 logger.info("Done")

--- a/tests/exceptions/source/modern/exception_formatting_async_generator_throw.py
+++ b/tests/exceptions/source/modern/exception_formatting_async_generator_throw.py
@@ -1,0 +1,30 @@
+import sys
+
+from loguru import logger
+
+logger.remove()
+logger.add(sys.stderr, format="", diagnose=False, backtrace=False, colorize=False)
+logger.add(sys.stderr, format="", diagnose=True, backtrace=False, colorize=False)
+logger.add(sys.stderr, format="", diagnose=False, backtrace=True, colorize=False)
+logger.add(sys.stderr, format="", diagnose=True, backtrace=True, colorize=False)
+
+
+@logger.catch
+async def foo(a, b):
+    yield a
+    yield b
+
+
+gen = foo(1, 0)
+
+op = gen.asend(None)
+try:
+    op.send(None)
+except StopIteration:
+    pass
+
+op = gen.athrow(ValueError("Bug"))
+try:
+    op.send(None)
+except StopAsyncIteration:
+    pass

--- a/tests/test_exceptions_formatting.py
+++ b/tests/test_exceptions_formatting.py
@@ -248,6 +248,7 @@ def test_exception_others(filename):
     [
         ("type_hints", (3, 6)),
         ("exception_formatting_async_generator", (3, 6)),
+        ("exception_formatting_async_generator_throw", (3, 6)),
         ("decorate_async_generator", (3, 7)),
         ("positional_only_argument", (3, 8)),
         ("walrus_operator", (3, 8)),


### PR DESCRIPTION
Fix #1503.

The unit tests are a quite convoluted (again, due to Python 3.5 syntax requirements and `asyncio` internals changing the traceback across versions), but in a nutshell the behavior can be tested with:

```python
import asyncio
from loguru import logger

@logger.catch
async def generator():
    yield 0
    yield 1


async def main():
    gen = generator()

    # Just to skip the first yield.
    await gen.asend(None)

    try:
        await gen.athrow(ValueError("Bug"))
    except StopAsyncIteration:
        pass
    

asyncio.run(main())
``` 

Without `@logger.catch()`, we can observe the exception is raised from within the generator:

```
Traceback (most recent call last):
  ...
  File "/home/delgan/Documents/code/loguru/demo.py", line 5, in generator
    yield 0
ValueError: Bug
```

Therefore, it makes sense such exception to be caught when adding `@logger.catch()`. It wasn't the case prior to this PR.

Note that the `except StopAsyncIteration` it tests code are expected and not a problem. This is the usual way for CPython to signal end of iterations. It doesn't show up very much in production code since we use `async for gen(): ...` which handles it automatically. Here, such usage is not possible since we want to use `athrow()`. 

Note also that the example above use two `yield` just to make the traceback more comprehensible. If `athrow()` is called directly at the start, then the traceback will points to the `@logger.catch()` / `async def generator()` line:

```
Traceback (most recent call last):
  ...
  File "/home/delgan/Documents/code/loguru/demo.py", line 4, in generator
    async def generator():
ValueError: Bug
```